### PR TITLE
Fix incorrect API call in teams widget. Fixes #36.

### DIFF
--- a/src/components/teams/Teams/index.js
+++ b/src/components/teams/Teams/index.js
@@ -51,7 +51,7 @@ module.exports = React.createClass({
 
     var props = this.props;
 
-    pages.findByCampaign(props.campaignUid, props.page_count, props.page_size, props.type, this.onSuccess);
+    pages.findByCampaign(props.campaignUid, props.type, props.page_size, props.page_count, this.onSuccess);
   },
 
   onSuccess: function(result) {


### PR DESCRIPTION
args were in the wrong order here causing an incorrect/incomplete API call.
