### PR TITLE
PR Add test-debug script

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "styles": "gulp styles",
     "styles-dev": "gulp styles --debug",
     "test": "jsxcs ./src/* --config=./config/jscs_config.json && jest",
+    "test-debug": "node --debug-brk --harmony ./node_modules/.bin/jest --runInBand",
     "start": "node server.js",
     "publish": "bin/version-check && gulp && gulp publish"
   },


### PR DESCRIPTION
To debug tests"
- install node-inspector if not already installed: `npm install -g node-inspector`
- launch node-inspector: `node-inspector` and open web browser at `http://localhost:8080/debug?port=5858`
- add `debugger;` statement(s) to test file you want to break at (easier than adding breakpoint in inspector)
- run your tests with `npm run test-debug <testfilename>` where <testfilename> is the name of the test file you want to debug (instead of running all tests).  You may need to update your version of node (`brew update && brew upgrade node`) if your npm version is < 2.0 to be able to pass args like the testfilename to npm scripts.
- refresh your node inspector browser and you'll see it's now connected and stopped at the first line.
- press the play button in top right to run your test

It will stop at the `debugger` statements and other breakpoints etc.  You can see the local vars in the righthand side, and pop open console at bottom to execute javascript code with current context etc.

![screen shot 2014-11-27 at 8 30 47 am](https://cloud.githubusercontent.com/assets/1740899/5209901/f827e3c2-760f-11e4-828d-d033f8118a6f.png)
![screen shot 2014-11-27 at 8 30 36 am](https://cloud.githubusercontent.com/assets/1740899/5209902/f93272a0-760f-11e4-8e4f-25fddfcdf8b1.png)
![screen shot 2014-11-27 at 8 31 30 am](https://cloud.githubusercontent.com/assets/1740899/5209903/fa4db500-760f-11e4-8b08-80fb9a7b2db4.png)
