### PR TITLE
Set border to 0.

### DIFF
--- a/src/components/charities/PromoCharitiesResult/style.scss
+++ b/src/components/charities/PromoCharitiesResult/style.scss
@@ -59,4 +59,5 @@
   display: inline-block;
   vertical-align: middle;
   max-width: 100%;
+  border: 0;
 }


### PR DESCRIPTION
Stops nasty borders from showing in nasty IE 8.

Before:
![screen shot 2014-12-09 at 9 21 26 am](https://cloud.githubusercontent.com/assets/859298/5349799/4209ca92-7f88-11e4-88bd-5a19aa377d7f.png)

After:
![screen shot 2014-12-09 at 9 19 16 am](https://cloud.githubusercontent.com/assets/859298/5349798/4207bc3e-7f88-11e4-99a8-2816bf1c4152.png)
