### PR TITLE
Add url to leaderboard images. Fixes #41.

### DIFF
--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -80,6 +80,7 @@ module.exports = React.createClass({
       return {
         id: page.id,
         name: page.name,
+        url: page.url,
         iso_code: page.amount.currency.iso_code,
         amount:  symbol + numeral(page.amount.cents / 100).format('0[.]00 a'),
         totalMembers: page.team_member_uids.length,
@@ -118,6 +119,7 @@ module.exports = React.createClass({
           <TeamLeaderboardItem
             key={ d.id }
             name={ d.name }
+            url={ d.url }
             iso_code={ d.iso_code }
             amount={ d.amount }
             totalMembers={ d.totalMembers }
@@ -133,6 +135,7 @@ module.exports = React.createClass({
           rank={ rank }
           rankTitle={ this.t('rankTitle') }
           name={ d.name }
+          url={ d.url }
           iso_code={ d.iso_code }
           amount={ d.amount }
           imgSrc={ d.medImgSrc } />

--- a/src/components/leaderboards/LeaderboardItem/index.js
+++ b/src/components/leaderboards/LeaderboardItem/index.js
@@ -9,9 +9,9 @@ module.exports = React.createClass({
     return (
       <li className="LeaderboardItem">
         <div className="LeaderboardItem__skin">
-          <div className="LeaderboardItem__image">
+          <a href={ this.props.url } className="LeaderboardItem__image">
             <img src={ this.props.imgSrc } />
-          </div>
+          </a>
           <div className="LeaderboardItem__content">
             <div className="LeaderboardItem__details">
               <div className="LeaderboardItem__name">

--- a/src/components/leaderboards/LeaderboardItem/style.scss
+++ b/src/components/leaderboards/LeaderboardItem/style.scss
@@ -80,6 +80,7 @@
   img {
     width: 100%;
     border-radius: 50%;
+    border: 0;
   }
 }
 

--- a/src/components/leaderboards/TeamLeaderboardItem/index.js
+++ b/src/components/leaderboards/TeamLeaderboardItem/index.js
@@ -9,9 +9,9 @@ module.exports = React.createClass({
     return (
       <li className="TeamLeaderboard__items-item">
         <div className="TeamLeaderboard__items-skin">
-          <div className="TeamLeaderboard__items-image">
+          <a href={ this.props.url } className="TeamLeaderboard__items-image">
             <img src={ this.props.imgSrc } />
-          </div>
+          </a>
           <div className="TeamLeaderboard__items-content">
             <div className="TeamLeaderboard__items-name">{ this.props.name }</div>
             <div className="TeamLeaderboard__items-stats">

--- a/src/components/leaderboards/TeamLeaderboardItem/style.scss
+++ b/src/components/leaderboards/TeamLeaderboardItem/style.scss
@@ -44,11 +44,13 @@
 
 .TeamLeaderboard__items-image {
   @include box-sizing(border-box);
+  display: block;
   padding: 15px 15px 0;
   text-align: center;
 
   img {
     width:100%;
+    border: 0;
   }
 
   @include media-max($breakpoint-l) {


### PR DESCRIPTION
Makes the images for leaderboards link to the team/individual page.
