### PR TITLE
Add prefix option to AddressLookup widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ Displays a form input field and country selector, which allows users to lookup t
 ##### Options
 
 - `required`: *optional* sets the address field as being required. Defaults to 'false'.
+- `prefix`: *optional* string to add a unique identifier to the input elements, for use when multiple AddressLookup widgets appear on the same page / post to the same form. Defaults to ''.
 - `country`: *optional* two-digit capitalized country ISO code (AU, GB, US, NZ, IE, etc). Default is 'US'.
 - `address`: *optional* object containing a pre-existing address to display. If provided, lookup functionality is not available. Use when user address already provided or when page reloads on form validation. Default is 'null'. Takes the form:
   ```js

--- a/src/components/address/AddressBreakdown/index.js
+++ b/src/components/address/AddressBreakdown/index.js
@@ -11,6 +11,7 @@ module.exports = React.createClass({
 
   propTypes: {
     address: React.PropTypes.object,
+    prefix: React.PropTypes.string,
     region: React.PropTypes.string,
     onChange: React.PropTypes.func
   },
@@ -18,6 +19,7 @@ module.exports = React.createClass({
   getDefaultProps: function() {
     return {
       address: null,
+      prefix: '',
       region: 'US',
       defaultI18n: {
         street_address: 'Address',
@@ -62,7 +64,7 @@ module.exports = React.createClass({
           ref={ 'street_address' }
           key={ 'street_address' }
           i18n={{
-            name: 'street_address',
+            name: this.props.prefix + 'street_address',
             label: this.t('street_address', { scope: iso })
           }}
           value={ address.street_address }
@@ -72,7 +74,7 @@ module.exports = React.createClass({
           key={ "extended_address" }
           ref={ 'extended_address' }
           i18n={{
-            name: 'extended_address',
+            name: this.props.prefix + 'extended_address',
             label: this.t('extended_address', { scope: iso })
           }}
           value={ address.extended_address }
@@ -83,7 +85,7 @@ module.exports = React.createClass({
           key={ "locality" }
           ref={ 'locality' }
           i18n={{
-            name: 'locality',
+            name: this.props.prefix + 'locality',
             label: this.t('locality', { scope: iso })
           }}
           value={ address.locality }
@@ -95,7 +97,7 @@ module.exports = React.createClass({
           key={ 'region' }
           ref={ 'region' }
           i18n={{
-            name: 'region',
+            name: this.props.prefix + 'region',
             label: this.t('region', { scope: iso })
           }}
           value={ address.region }
@@ -107,7 +109,7 @@ module.exports = React.createClass({
           key={ "country_name" }
           ref={ 'country_name' }
           i18n={{
-            name: 'country_name',
+            name: this.props.prefix + 'country_name',
             label: this.t('country_name', { scope: iso })
           }}
           value={ address.country_name }
@@ -119,7 +121,7 @@ module.exports = React.createClass({
           key={ "postal_code" }
           ref={ 'postal_code' }
           i18n={{
-            name: 'postal_code',
+            name: this.props.prefix + 'postal_code',
             label: this.t('postal_code', { scope: iso })
           }}
           value={ address.postal_code }

--- a/src/components/address/AddressLookup/__tests__/AddressLookup-test.js
+++ b/src/components/address/AddressLookup/__tests__/AddressLookup-test.js
@@ -58,6 +58,15 @@ describe('AddressLookup', function() {
     expect(locality.value).toBe('Sydney');
   });
 
+  it('can be uniquely prefixed', function() {
+    var element = TestUtils.renderIntoDocument(<AddressLookup prefix={ 'testPrefix-' } address={ addressFindResult.address } />);
+    var breakdown = findByClass(element, 'AddressBreakdown');
+    var streetAddress = findByProp(breakdown, 'name', 'testPrefix-street_address').getDOMNode();
+    var locality = findByProp(breakdown, 'name', 'testPrefix-locality').getDOMNode();
+    expect(streetAddress.value).toBe('1 Place Pl');
+    expect(locality.value).toBe('Sydney');
+  });
+
   it('returns a list of addresses', function() {
     var element = TestUtils.renderIntoDocument(<AddressLookup />);
     var input = findByClass(element, 'Input__input').getDOMNode();

--- a/src/components/address/AddressLookup/index.js
+++ b/src/components/address/AddressLookup/index.js
@@ -18,6 +18,7 @@ module.exports = React.createClass({
   propTypes: {
     required: React.PropTypes.bool,
     output: React.PropTypes.func,
+    prefix: React.PropTypes.string,
     country: React.PropTypes.string,
     address: React.PropTypes.object,
     paf_valid: React.PropTypes.bool,
@@ -29,6 +30,7 @@ module.exports = React.createClass({
       required: false,
       output: function() {},
       country: 'US',
+      prefix: '',
       address: null,
       paf_valid: false,
       defaultI18n: {
@@ -211,6 +213,7 @@ module.exports = React.createClass({
     return bool && (
       <CountrySelect
         ref="countrySelect"
+        prefix={ this.props.prefix }
         selected={ this.state.country }
         open={ this.state.choosingCountry }
         onOpen={ this.chooseCountry }
@@ -225,7 +228,7 @@ module.exports = React.createClass({
         ref={ 'lookup' }
         required={ this.props.required }
         i18n={{
-          name: 'lookup',
+          name: this.props.prefix + 'lookup',
           label: this.state.country === 'GB' ? this.t('inputLabelGB') : this.t('inputLabel')
         }}
         value={ this.state.input }
@@ -262,6 +265,7 @@ module.exports = React.createClass({
   renderAddress: function(address) {
     return address && (
       <AddressBreakdown
+        prefix={ this.props.prefix }
         required={ this.props.required }
         address={ address }
         region={ this.state.country }

--- a/src/components/address/CountrySelect/index.js
+++ b/src/components/address/CountrySelect/index.js
@@ -12,6 +12,7 @@ module.exports = React.createClass({
   displayName: "CountrySelect",
 
   propTypes: {
+    prefix: React.PropTypes.string,
     selected: React.PropTypes.string,
     open: React.PropTypes.bool,
     onOpen: React.PropTypes.func,
@@ -20,6 +21,7 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
+      prefix: '',
       selected: 'US',
       open: false
     };
@@ -124,7 +126,7 @@ module.exports = React.createClass({
         ref={ 'countryFilter' }
         key={ "countryFilter" }
         i18n={{
-          name: 'countryFilter',
+          name: this.props.prefix + 'countryFilter',
           label: "Find Country"
         }}
         value={ this.state.filter }


### PR DESCRIPTION
This allows multiple AddressLookup widgets to appear on the same page / form, by prefixing the 'name' and 'id' attributes of its inputs with an optional string. Required for the command_centre donation form. 
