### PR TITLE
full width overlay background

### DIFF
--- a/src/components/helpers/Overlay/style.scss
+++ b/src/components/helpers/Overlay/style.scss
@@ -33,4 +33,5 @@
   position: fixed;
   top: 0;
   bottom: 0;
+  width: 100%;
 }


### PR DESCRIPTION
This class is being applied to the body while the overlay / modal is visible. A normal html body will get squashed to the side unless `width: 100%` is specified.
