### PR TITLE
Expose number formatting as optional prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Displays the total funds raised for a single specified campaign as a dollar amou
 - `renderIcon`: *optional* boolean. Set to `true` by default.
 - `backgroundColor`: *optional* string. Set to `'#525252'` by default.
 - `textColor`: *optional* string. Set to `'#FFFFFF'` by default.
+- `format`: *optional* string. Set to `'0.00 a'` by default. [More format strings](http://numeraljs.com/).
 - `i18n`: *optional* object containing localised text. Default i18n is:
 
   ```js
@@ -186,6 +187,7 @@ Displays the total number of fundraisers (that have a page) for a single specifi
 - `backgroundColor`: *optional* string. Set to `'#525252'` by default.
 - `textColor`: *optional* string. Set to `'#FFFFFF'` by default.
 - `renderIcon`: *optional* boolean. Set to `true` by default.
+- `format`: *optional* string. Set to `'0,0'` by default. [More format strings](http://numeraljs.com/).
 - `i18n`: *optional* object containing localised text. Default i18n is:
 
   ```js
@@ -225,6 +227,7 @@ Displays the total number of charities associated with a single specified campai
 - `backgroundColor`: *optional* string. Set to `'#525252'` by default.
 - `textColor`: *optional* string. Set to `'#FFFFFF'` by default.
 - `renderIcon`: *optional* boolean. Set to `true` by default.
+- `format`: *optional* string. Set to `'0,0 a'` by default. [More format strings](http://numeraljs.com/).
 - `i18n`: *optional* object containing localised text. Default i18n is:
 
   ```js
@@ -263,6 +266,7 @@ Set a goal in cents to display as a campaign goal.
 - `renderIcon`: *optional* boolean. Set to `true` by default.
 - `backgroundColor`: *optional* string. Set to `'#525252'` by default.
 - `textColor`: *optional* string. Set to `'#FFFFFF'` by default.
+- `format`: *optional* string. Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).
 - `i18n`: *optional* object containing localised text. Default i18n is:
 
   ```js
@@ -303,6 +307,7 @@ Displays the total recorded distance that fundraisers have run for a single spec
 - `renderIcon`: *optional* boolean. Set to `true` by default.
 - `backgroundColor`: *optional* string. Set to `'#525252'` by default.
 - `textColor`: *optional* string. Set to `'#FFFFFF'` by default.
+- `format`: *optional* string. Set to `'0,0[.]0[0]'` by default. [More format strings](http://numeraljs.com/).
 - `i18n`: *optional* object containing localised text. Default i18n is:
 
   ```js
@@ -342,6 +347,7 @@ Displays the total recorded time that fundraisers have run for a single specifie
 - `renderIcon`: *optional* boolean. Set to `true` by default.
 - `backgroundColor`: *optional* string. Set to `'#525252'` by default.
 - `textColor`: *optional* string. Set to `'#FFFFFF'` by default.
+- `format`: *optional* string. Set to `'0,0[.]0[0]'` by default. [More format strings](http://numeraljs.com/).
 - `i18n`: *optional* object containing localised text. Default i18n is:
 
   ```js
@@ -531,6 +537,7 @@ Displays a leaderboard sorted by funds raised (highest first) for a single speci
 - `pageSize`: *optional* number. Set to `12` by default. Determines how many results to show per page.
 - `backgroundColor`: *optional* string. Set to `'#EBEBEB'` by default.
 - `textColor`: *optional* string. Set to `'#333333'` by default.
+- `currencyFormat`: *optional* string. Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).
 - `i18n`: *optional* object containing localised text. Default i18n is:
 
   ```js

--- a/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
+++ b/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
@@ -103,7 +103,7 @@ describe('Leaderboard', function() {
       var leaderboard = <Leaderboard campaignUid="au-0" />;
       var element = TestUtils.renderIntoDocument(leaderboard);
 
-      expect(element.formatAmount(10000)).toEqual('$100');
+      expect(element.formatAmount(10000)).toEqual('$100 ');
     });
 
     it('renders a different format if given acceptable numeral.js string', function() {

--- a/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
+++ b/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
@@ -103,11 +103,11 @@ describe('Leaderboard', function() {
       var leaderboard = <Leaderboard campaignUid="au-0" />;
       var element = TestUtils.renderIntoDocument(leaderboard);
 
-      expect(element.formatAmount(10000)).toEqual('$100 ');
+      expect(element.formatAmount(10000)).toEqual('$100');
     });
 
     it('renders a different format if given acceptable numeral.js string', function() {
-      var leaderboard = <Leaderboard campaignUid="au-0" format="0.00" />;
+      var leaderboard = <Leaderboard campaignUid="au-0" currencyFormat="0.00" />;
       var element = TestUtils.renderIntoDocument(leaderboard);
 
       expect(element.formatAmount(10000)).toEqual('$100.00');

--- a/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
+++ b/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
@@ -12,7 +12,7 @@ describe('Leaderboard', function() {
   var findByClass     = TestUtils.findRenderedDOMComponentWithClass;
   var scryByClass     = TestUtils.scryRenderedDOMComponentsWithClass;
 
-  describe('component defaults', function() {
+  describe('Component defaults', function() {
     var leaderboard;
     var element;
 
@@ -37,7 +37,7 @@ describe('Leaderboard', function() {
     });
   });
 
-  describe('component props', function() {
+  describe('Custom component props', function() {
     var leaderboard;
     var element;
     var translation = {
@@ -95,6 +95,22 @@ describe('Leaderboard', function() {
 
       element.rankLeaderboard(data);
       expect(_.pluck(data, 'rank')).toEqual([1, 2, 2, 2, 5]);
+    });
+  });
+
+  describe('Number formatting options', function() {
+    it('renders in a short format by default', function() {
+      var leaderboard = <Leaderboard campaignUid="au-0" />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+
+      expect(element.formatAmount(10000)).toEqual('$100 ');
+    });
+
+    it('renders a different format if given acceptable numeral.js string', function() {
+      var leaderboard = <Leaderboard campaignUid="au-0" format="0.00" />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+
+      expect(element.formatAmount(10000)).toEqual('$100.00');
     });
   });
 });

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -32,7 +32,7 @@ module.exports = React.createClass({
       pageSize: 12,
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
-      format: '0[.]00 a',
+      currencyFormat: '0[.]00 a',
       defaultI18n: {
         raisedTitle: 'Raised',
         membersTitle: 'Members',

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -20,7 +20,7 @@ module.exports = React.createClass({
     pageSize: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
-    format: React.PropTypes.string,
+    currencyFormat: React.PropTypes.string,
     i18n: React.PropTypes.object
   },
 
@@ -126,7 +126,7 @@ module.exports = React.createClass({
   },
 
   formatAmount: function(amount) {
-    return this.t('symbol') + numeral(amount / 100).format(this.props.format);
+    return this.t('symbol') + numeral(amount / 100).format(this.props.currencyFormat);
   },
 
   renderLeaderboardItems: function() {

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -20,6 +20,7 @@ module.exports = React.createClass({
     pageSize: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
+    format: React.PropTypes.string,
     i18n: React.PropTypes.object
   },
 
@@ -31,6 +32,7 @@ module.exports = React.createClass({
       pageSize: 12,
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
+      format: '0[.]00 a',
       defaultI18n: {
         raisedTitle: 'Raised',
         membersTitle: 'Members',
@@ -46,7 +48,6 @@ module.exports = React.createClass({
       isLoading: false,
       pageIds: [],
       boardData: [],
-      pagedBoardData: [],
       currentPage: 1
     };
   },
@@ -67,10 +68,7 @@ module.exports = React.createClass({
 
   loadPages: function(result) {
     var pageIds = result.leaderboard.page_ids;
-
-    this.setState({
-      pageIds: pageIds
-    });
+    this.setState({ pageIds: pageIds });
 
     pages.findByIds(pageIds, this.processLeaderboard);
   },
@@ -127,17 +125,20 @@ module.exports = React.createClass({
     return pagedLeaderboard;
   },
 
+  formatAmount: function(amount) {
+    return this.t('symbol') + numeral(amount / 100).format(this.props.format);
+  },
+
   renderLeaderboardItems: function() {
     var boardData   = this.state.boardData;
     var currentPage = this.state.currentPage - 1;
-    var symbol      = this.t('symbol');
 
     if (this.state.isLoading) {
       return <Icon className="Leaderboard__loading" icon="refresh" />;
     }
 
     return boardData[currentPage].map(function(d,i) {
-      var formattedAmount = symbol + numeral(d.amount / 100).format('0[.]00 a');
+      var formattedAmount = this.formatAmount(d.amount);
       var formattedRank = numeral(d.rank).format('0o');
 
       if (this.props.type === 'team') {

--- a/src/components/leaderboards/LeaderboardItem/__tests__/LeaderboardItem-test.js
+++ b/src/components/leaderboards/LeaderboardItem/__tests__/LeaderboardItem-test.js
@@ -2,12 +2,12 @@
 jest.autoMockOff();
 
 describe('LeaderboardItem', function() {
-  var React                       = require('react/addons');
-  var LeaderboardItem             = require('../');
-  var TestUtils                   = React.addons.TestUtils;
-  var findByClass                 = TestUtils.findRenderedDOMComponentWithClass;
+  var React           = require('react/addons');
+  var LeaderboardItem = require('../');
+  var TestUtils       = React.addons.TestUtils;
+  var findByClass     = TestUtils.findRenderedDOMComponentWithClass;
 
-  describe('component defaults', function() {
+  describe('Component defaults', function() {
     var leaderboardItem;
     var element;
 

--- a/src/components/leaderboards/TeamLeaderboardItem/index.js
+++ b/src/components/leaderboards/TeamLeaderboardItem/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var React         = require('react');
+var React = require('react');
 
 module.exports = React.createClass({
   displayName: 'TeamLeaderboardItem',

--- a/src/components/totals/FundsRaised/__tests__/FundsRaised-test.js
+++ b/src/components/totals/FundsRaised/__tests__/FundsRaised-test.js
@@ -3,11 +3,11 @@ jest.autoMockOff();
 jest.mock('../../../../api/campaigns');
 
 describe('FundsRaised', function() {
-  var React                       = require('react/addons');
-  var FundsRaised                 = require('../');
-  var campaigns                   = require('../../../../api/campaigns');
-  var TestUtils                   = React.addons.TestUtils;
-  var findByClass                 = TestUtils.findRenderedDOMComponentWithClass;
+  var React       = require('react/addons');
+  var FundsRaised = require('../');
+  var campaigns   = require('../../../../api/campaigns');
+  var TestUtils   = React.addons.TestUtils;
+  var findByClass = TestUtils.findRenderedDOMComponentWithClass;
 
   describe('component defaults', function() {
     var fundsRaised;
@@ -77,6 +77,34 @@ describe('FundsRaised', function() {
       var total = findByClass(element, 'FundsRaised__total');
 
       expect(total.getDOMNode().textContent).toContain('£0.00');
+    });
+  });
+
+  describe('Number formatting options', function() {
+    it('renders in a short format by default', function() {
+      var fundsRaised = <FundsRaised campaignUid="au-0" />;
+      var element = TestUtils.renderIntoDocument(fundsRaised);
+
+      element.setState({
+        isLoading: false,
+        total: 1000000
+      });
+
+      var total = findByClass(element, 'FundsRaised__total');
+      expect(total.getDOMNode().textContent).toBe('$10.00 k');
+    });
+
+    it('renders a different format if given acceptable numeral.js string', function() {
+      var fundsRaised = <FundsRaised campaignUid="au-0" format="0[.]0" />;
+      var element = TestUtils.renderIntoDocument(fundsRaised);
+
+      element.setState({
+        isLoading: false,
+        total: 1000000
+      });
+
+      var total = findByClass(element, 'FundsRaised__total');
+      expect(total.getDOMNode().textContent).toBe('$10000');
     });
   });
 });

--- a/src/components/totals/FundsRaised/index.js
+++ b/src/components/totals/FundsRaised/index.js
@@ -14,7 +14,8 @@ module.exports = React.createClass({
     renderIcon: React.PropTypes.bool,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
-    i18n: React.PropTypes.object,
+    format: React.PropTypes.string,
+    i18n: React.PropTypes.object
   },
 
   getDefaultProps: function() {
@@ -23,6 +24,7 @@ module.exports = React.createClass({
       renderIcon: true,
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
+      format: '0.00 a',
       defaultI18n: {
         title: 'Raised To Date',
         symbol: '$'
@@ -55,7 +57,7 @@ module.exports = React.createClass({
   renderTotal: function() {
     var symbol = this.t('symbol');
     var totalDollars = this.state.total / 100;
-    var formattedTotal = symbol + numeral(totalDollars).format('0.00 a');
+    var formattedTotal = symbol + numeral(totalDollars).format(this.props.format);
     var title = this.t('title');
 
     if (this.state.isLoading) {

--- a/src/components/totals/Goal/__tests__/Goal-test.js
+++ b/src/components/totals/Goal/__tests__/Goal-test.js
@@ -7,7 +7,7 @@ describe('Goal', function() {
   var TestUtils                   = React.addons.TestUtils;
   var findByClass                 = TestUtils.findRenderedDOMComponentWithClass;
 
-  describe('component defaults', function() {
+  describe('Component defaults', function() {
     var goal;
     var element;
 
@@ -41,7 +41,7 @@ describe('Goal', function() {
     });
   });
 
-  describe('component props', function() {
+  describe('Custom component props', function() {
     var goal;
     var element;
     var translation = {
@@ -68,4 +68,23 @@ describe('Goal', function() {
       expect(total.getDOMNode().textContent).toContain('£50 k');
     });
   });
+
+  describe('Number formatting options', function() {
+    it('renders in a short format by default', function() {
+      var goal = <Goal goal="5000000" />;
+      var element = TestUtils.renderIntoDocument(goal);
+      var total = findByClass(element, 'Goal__total');
+
+      expect(total.getDOMNode().textContent).toBe('$50 k');
+    });
+
+    it('renders a different format if given acceptable numeral.js string', function() {
+      var goal = <Goal goal="5000000" format="0,0.00" />;
+      var element = TestUtils.renderIntoDocument(goal);
+      var total = findByClass(element, 'Goal__total');
+
+      expect(total.getDOMNode().textContent).toBe('$50,000.00');
+    });
+  });
+
 });

--- a/src/components/totals/Goal/index.js
+++ b/src/components/totals/Goal/index.js
@@ -13,7 +13,8 @@ module.exports = React.createClass({
     renderIcon: React.PropTypes.bool,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
-    i18n: React.PropTypes.object,
+    format: React.PropTypes.string,
+    i18n: React.PropTypes.object
   },
 
   getDefaultProps: function() {
@@ -23,6 +24,7 @@ module.exports = React.createClass({
       goal: 0,
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
+      format: '0[.]00 a',
       defaultI18n: {
         title: 'Goal',
         symbol: '$'
@@ -34,7 +36,7 @@ module.exports = React.createClass({
     var title = this.t('title');
     var symbol = this.t('symbol');
     var goal = this.props.goal / 100;
-    var formattedTotal = symbol + numeral(goal).format('0[.]00 a');
+    var formattedTotal = symbol + numeral(goal).format(this.props.format);
 
     return (
       <div>

--- a/src/components/totals/TotalCharities/__tests__/TotalCharities-test.js
+++ b/src/components/totals/TotalCharities/__tests__/TotalCharities-test.js
@@ -3,14 +3,14 @@ jest.autoMockOff();
 jest.mock('../../../../api/charities');
 
 describe('TotalCharities', function() {
-  var React                       = require('react/addons');
-  var TotalCharities              = require('../');
-  var charities                   = require('../../../../api/charities');
-  var TestUtils                   = React.addons.TestUtils;
-  var scryByTag                   = TestUtils.scryRenderedDOMComponentsWithTag;
-  var findByClass                 = TestUtils.findRenderedDOMComponentWithClass;
+  var React          = require('react/addons');
+  var TotalCharities = require('../');
+  var charities      = require('../../../../api/charities');
+  var TestUtils      = React.addons.TestUtils;
+  var scryByTag      = TestUtils.scryRenderedDOMComponentsWithTag;
+  var findByClass    = TestUtils.findRenderedDOMComponentWithClass;
 
-  describe('component defaults', function() {
+  describe('Component defaults', function() {
     var totalCharities;
     var element;
 
@@ -53,7 +53,7 @@ describe('TotalCharities', function() {
     });
   });
 
-  describe('component props', function() {
+  describe('Custom component props', function() {
     var totalCharities;
     var element;
     var translation = {
@@ -77,6 +77,34 @@ describe('TotalCharities', function() {
       var total = findByClass(element, 'TotalCharities__total');
 
       expect(total.getDOMNode().textContent).toContain('0');
+    });
+  });
+
+  describe('Number formatting options', function() {
+    it('renders in a short format by default', function() {
+      var totalCharities = <TotalCharities campaignUid="au-0" />;
+      var element = TestUtils.renderIntoDocument(totalCharities);
+
+      element.setState({
+        isLoading: false,
+        total: 10000
+      });
+
+      var total = findByClass(element, 'TotalCharities__total');
+      expect(total.getDOMNode().textContent).toBe('10 k');
+    });
+
+    it('renders a different format if given acceptable numeral.js string', function() {
+      var totalCharities = <TotalCharities campaignUid="au-0" format="0,0" />;
+      var element = TestUtils.renderIntoDocument(totalCharities);
+
+      element.setState({
+        isLoading: false,
+        total: 10000
+      });
+
+      var total = findByClass(element, 'TotalCharities__total');
+      expect(total.getDOMNode().textContent).toBe('10,000');
     });
   });
 });

--- a/src/components/totals/TotalCharities/index.js
+++ b/src/components/totals/TotalCharities/index.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var React             = require('react');
-var I18nMixin         = require('../../mixins/I18n');
-var charities         = require('../../../api/charities');
-var Icon              = require('../../helpers/Icon');
-var numeral           = require('numeral');
+var React     = require('react');
+var I18nMixin = require('../../mixins/I18n');
+var charities = require('../../../api/charities');
+var Icon      = require('../../helpers/Icon');
+var numeral   = require('numeral');
 
 module.exports = React.createClass({
   mixins: [I18nMixin],
@@ -14,7 +14,8 @@ module.exports = React.createClass({
     renderIcon: React.PropTypes.bool,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
-    i18n: React.PropTypes.object,
+    format: React.PropTypes.string,
+    i18n: React.PropTypes.object
   },
 
   getDefaultProps: function() {
@@ -23,6 +24,7 @@ module.exports = React.createClass({
       renderIcon: true,
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
+      format: '0,0 a',
       defaultI18n: {
         title: 'Non Profits'
       }
@@ -52,7 +54,7 @@ module.exports = React.createClass({
 
   renderTotal: function() {
     var totalCharities = this.state.total;
-    var formattedTotal = numeral(totalCharities).format('0,0');
+    var formattedTotal = numeral(totalCharities).format(this.props.format);
     var title = this.t('title');
 
     if (this.state.isLoading) {

--- a/src/components/totals/TotalDistance/__tests__/TotalDistance-test.js
+++ b/src/components/totals/TotalDistance/__tests__/TotalDistance-test.js
@@ -3,14 +3,13 @@ jest.autoMockOff();
 jest.mock('../../../../api/campaigns');
 
 describe('TotalDistance', function() {
-  var React                       = require('react/addons');
-  var TotalDistance               = require('../');
-  var campaigns                   = require('../../../../api/campaigns');
-  var TestUtils                   = React.addons.TestUtils;
-  var scryByClass                 = TestUtils.scryRenderedDOMComponentsWithClass;
-  var findByClass                 = TestUtils.findRenderedDOMComponentWithClass;
+  var React         = require('react/addons');
+  var TotalDistance = require('../');
+  var campaigns     = require('../../../../api/campaigns');
+  var TestUtils     = React.addons.TestUtils;
+  var findByClass   = TestUtils.findRenderedDOMComponentWithClass;
 
-  describe('component defaults', function() {
+  describe('Component defaults', function() {
     var totalDistance;
     var element;
 
@@ -39,7 +38,7 @@ describe('TotalDistance', function() {
     });
   });
 
-  describe('component props', function() {
+  describe('Custom component props', function() {
     var totalDistance;
     var element;
     var translation = {
@@ -49,16 +48,49 @@ describe('TotalDistance', function() {
     beforeEach(function() {
       totalDistance = <TotalDistance i18n={ translation } renderIcon={ false } />;
       element = TestUtils.renderIntoDocument(totalDistance);
-    });
-
-    it('renders a custom title', function() {
       element.setState({
         isLoading: false,
         hasResults: true
       });
-      var title = findByClass(element, 'TotalDistance__title');
+    });
 
+    it('renders a custom title', function() {
+      var title = findByClass(element, 'TotalDistance__title');
       expect(title.getDOMNode().textContent).toBe(translation.title);
+    });
+
+    it('renders no icon', function() {
+      expect(element.renderIcon()).toBeUndefined();
+    });
+  });
+
+  describe('Number formatting options', function() {
+    it('renders in a human readable format by default', function() {
+      var totalDistance = <TotalDistance campaignUid="au-0" unit="km" />;
+      var element = TestUtils.renderIntoDocument(totalDistance);
+
+      element.setState({
+        isLoading: false,
+        hasResults: true,
+        total: 1000050
+      });
+
+      var total = findByClass(element, 'TotalDistance__total');
+      expect(total.getDOMNode().textContent).toBe('10,000.5');
+    });
+
+    it('renders a different format if given acceptable numeral.js string', function() {
+      var totalDistance = <TotalDistance campaignUid="au-0" unit="km" format="0.00" />;
+      var element = TestUtils.renderIntoDocument(totalDistance);
+
+      element.setState({
+        isLoading: false,
+        hasResults: true,
+        total: 1000050
+      });
+
+      var total = findByClass(element, 'TotalDistance__total');
+      expect(total.getDOMNode().textContent).toBe('10000.50');
     });
   });
 });

--- a/src/components/totals/TotalDistance/index.js
+++ b/src/components/totals/TotalDistance/index.js
@@ -15,7 +15,8 @@ module.exports = React.createClass({
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
     unit: React.PropTypes.oneOf(['km', 'miles']),
-    i18n: React.PropTypes.object,
+    format: React.PropTypes.string,
+    i18n: React.PropTypes.object
   },
 
   getDefaultProps: function() {
@@ -25,6 +26,7 @@ module.exports = React.createClass({
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
       unit: 'miles',
+      format: '0,0[.]0[0]',
       defaultI18n: {
         title: 'Miles',
         emptyLabel: 'No data to display.'
@@ -74,9 +76,9 @@ module.exports = React.createClass({
     var formattedTotal;
 
     if (this.props.unit === 'km') {
-      formattedTotal = numeral(totalKms).format('0,0[.]00');
+      formattedTotal = numeral(totalKms).format(this.props.format);
     } else {
-      formattedTotal = numeral(totalMiles).format('0,0[.]00');
+      formattedTotal = numeral(totalMiles).format(this.props.format);
     }
 
     if (this.state.isLoading) {

--- a/src/components/totals/TotalHeroes/__tests__/TotalHeroes-test.js
+++ b/src/components/totals/TotalHeroes/__tests__/TotalHeroes-test.js
@@ -3,13 +3,13 @@ jest.autoMockOff();
 jest.mock('../../../../api/pages');
 
 describe('TotalHeroes', function() {
-  var React                       = require('react/addons');
-  var TotalHeroes                 = require('../');
-  var pages                       = require('../../../../api/pages');
-  var TestUtils                   = React.addons.TestUtils;
-  var findByClass                 = TestUtils.findRenderedDOMComponentWithClass;
+  var React       = require('react/addons');
+  var TotalHeroes = require('../');
+  var pages       = require('../../../../api/pages');
+  var TestUtils   = React.addons.TestUtils;
+  var findByClass = TestUtils.findRenderedDOMComponentWithClass;
 
-  describe('component defaults', function() {
+  describe('Component defaults', function() {
     var totalHeroes;
     var element;
 
@@ -52,7 +52,7 @@ describe('TotalHeroes', function() {
     });
   });
 
-  describe('component props', function() {
+  describe('Custom component props', function() {
     var totalHeroes;
     var element;
     var translation = {
@@ -76,6 +76,34 @@ describe('TotalHeroes', function() {
       var total = findByClass(element, 'TotalHeroes__total');
 
       expect(total.getDOMNode().textContent).toContain('0');
+    });
+  });
+
+  describe('Number formatting options', function() {
+    it('renders in a standard format by default', function() {
+      var totalHeroes = <TotalHeroes campaignUid="au-0" />;
+      var element = TestUtils.renderIntoDocument(totalHeroes);
+
+      element.setState({
+        isLoading: false,
+        total: 10050
+      });
+
+      var total = findByClass(element, 'TotalHeroes__total');
+      expect(total.getDOMNode().textContent).toBe('10,050');
+    });
+
+    it('renders a different format if given acceptable numeral.js string', function() {
+      var totalHeroes = <TotalHeroes campaignUid="au-0" unit="km" format="0.00" />;
+      var element = TestUtils.renderIntoDocument(totalHeroes);
+
+      element.setState({
+        isLoading: false,
+        total: 10050
+      });
+
+      var total = findByClass(element, 'TotalHeroes__total');
+      expect(total.getDOMNode().textContent).toBe('10050.00');
     });
   });
 });

--- a/src/components/totals/TotalHeroes/index.js
+++ b/src/components/totals/TotalHeroes/index.js
@@ -16,6 +16,7 @@ module.exports = React.createClass({
     renderIcon: React.PropTypes.bool,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
+    format: React.PropTypes.string,
     i18n: React.PropTypes.object
   },
 
@@ -28,6 +29,7 @@ module.exports = React.createClass({
       renderIcon: true,
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
+      format: '0,0',
       defaultI18n: {
         title: 'Heroes'
       }
@@ -60,7 +62,7 @@ module.exports = React.createClass({
 
   renderTotal: function() {
     var totalHeroes = this.state.total;
-    var formattedTotal = numeral(totalHeroes).format('0,0');
+    var formattedTotal = numeral(totalHeroes).format(this.props.format);
     var title = this.t('title');
 
     if (this.state.isLoading) {

--- a/src/components/totals/TotalHours/__tests__/TotalHours-test.js
+++ b/src/components/totals/TotalHours/__tests__/TotalHours-test.js
@@ -3,13 +3,13 @@ jest.autoMockOff();
 jest.mock('../../../../api/campaigns');
 
 describe('TotalDistance', function() {
-  var React                       = require('react/addons');
-  var TotalHours               = require('../');
-  var campaigns                   = require('../../../../api/campaigns');
-  var TestUtils                   = React.addons.TestUtils;
-  var findByClass                 = TestUtils.findRenderedDOMComponentWithClass;
+  var React       = require('react/addons');
+  var TotalHours  = require('../');
+  var campaigns   = require('../../../../api/campaigns');
+  var TestUtils   = React.addons.TestUtils;
+  var findByClass = TestUtils.findRenderedDOMComponentWithClass;
 
-  describe('component defaults', function() {
+  describe('Component defaults', function() {
     var totalHours;
     var element;
 
@@ -24,7 +24,6 @@ describe('TotalDistance', function() {
 
     it('renders an icon by default', function() {
       var icon = findByClass(element, 'TotalHours__icon');
-
       expect(icon).not.toBeNull();
     });
 
@@ -38,7 +37,7 @@ describe('TotalDistance', function() {
     });
   });
 
-  describe('component props', function() {
+  describe('Custom component props', function() {
     var totalHours;
     var element;
     var translation = {
@@ -58,6 +57,36 @@ describe('TotalDistance', function() {
       var title = findByClass(element, 'TotalHours__title');
 
       expect(title.getDOMNode().textContent).toBe(translation.title);
+    });
+  });
+
+  describe('Number formatting options', function() {
+    it('renders in a human readable format by default', function() {
+      var totalHours = <TotalHours campaignUid="au-0" />;
+      var element = TestUtils.renderIntoDocument(totalHours);
+
+      element.setState({
+        isLoading: false,
+        hasResults: true,
+        total: 37800
+      });
+
+      var total = findByClass(element, 'TotalHours__total');
+      expect(total.getDOMNode().textContent).toBe('10.5');
+    });
+
+    it('renders a different format if given acceptable numeral.js string', function() {
+      var totalHours = <TotalHours campaignUid="au-0" format="0,0[.]00" />;
+      var element = TestUtils.renderIntoDocument(totalHours);
+
+      element.setState({
+        isLoading: false,
+        hasResults: true,
+        total: 37800
+      });
+
+      var total = findByClass(element, 'TotalHours__total');
+      expect(total.getDOMNode().textContent).toBe('10.50');
     });
   });
 });

--- a/src/components/totals/TotalHours/index.js
+++ b/src/components/totals/TotalHours/index.js
@@ -15,7 +15,8 @@ module.exports = React.createClass({
     renderIcon: React.PropTypes.bool,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
-    i18n: React.PropTypes.object,
+    format: React.PropTypes.string,
+    i18n: React.PropTypes.object
   },
 
   getDefaultProps: function() {
@@ -24,6 +25,7 @@ module.exports = React.createClass({
       renderIcon: true,
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
+      format: '0,0[.]0[0]',
       defaultI18n: {
         title: 'Hours',
         emptyLabel: 'No data to display.'
@@ -40,10 +42,7 @@ module.exports = React.createClass({
   },
 
   componentWillMount: function() {
-    this.setState({
-      isLoading: true
-    });
-
+    this.setState({ isLoading: true });
     campaigns.find(this.props.campaignUid, this.onSuccess);
   },
 
@@ -67,7 +66,7 @@ module.exports = React.createClass({
   renderTotal: function() {
     var symbol         = this.t('symbol');
     var totalHrs       = this.state.total * 0.000277778;
-    var formattedTotal = numeral(totalHrs).format('0,0[.]00');
+    var formattedTotal = numeral(totalHrs).format(this.props.format);
     var title          = this.t('title');
     var emptyLabel     = this.t('emptyLabel');
 


### PR DESCRIPTION
Made minor changes to each component that displays a total as a number. The formatting is now exposed as a prop so you can pass in a valid [numeral.js](http://numeraljs.com/) string to format the number in different ways easily.

Also updated tests and README.