### PR TITLE
Se make goal generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ Set and display a campaign goal. While this component can be configured to displ
 
 ##### Options
 
-- `goal`: *required* number. Set a goal in **cents** to be rendered as a dollar amount.
-- `renderIcon`: *optional* boolean. Set to `true` by default.
+- `goal`: *required* number. Set a goal, rendered as a dollar value by default.
+- `renderIcon`: *optional* string or boolean. Set to `true` by default. Pass in a valid [FontAwesome](http://fortawesome.github.io/Font-Awesome/icons/) icon name (without the _fa_ prefix) to override the default; View an example below. Set to `false` to render no icon.
 - `backgroundColor`: *optional* string. Set to `'#525252'` by default.
 - `textColor`: *optional* string. Set to `'#FFFFFF'` by default.
 - `format`: *optional* string. Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).
@@ -292,6 +292,26 @@ Set and display a campaign goal. While this component can be configured to displ
     <div id="GoalExample">Loading...</div>
     <script>
       edh.widgets.renderWidget('GoalExample', 'Goal', { goal: 500000, i18n: { title: '2015 Goal' } });
+    </script>
+  </body>
+</html>
+```
+
+##### Example displaying a distance goal, with a custom icon
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="//d1ig6folwd6a9s.cloudfront.net/widgets-[0.0.0].css" rel="stylesheet">
+    <script src="//d1ig6folwd6a9s.cloudfront.net/widgets-[0.0.0].js"></script>
+  </head>
+  <body>
+    <div id="GoalExample">Loading...</div>
+    <script>
+      edh.widgets.renderWidget('GoalExample', 'Goal', { goal: 500, renderIcon: 'road', handleCents: false, i18n: { title: 'Distance Goal', suffix: 'km' } });
     </script>
   </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Displays the total number of charities associated with a single specified campai
 
 #### Campaign Goal (Campaign)
 
-Set a goal in cents to display as a campaign goal.
+Set and display a campaign goal. While this component can be configured to display any type of goal it renders as a dollar amount by default.
 
 ##### Options
 
@@ -267,6 +267,7 @@ Set a goal in cents to display as a campaign goal.
 - `backgroundColor`: *optional* string. Set to `'#525252'` by default.
 - `textColor`: *optional* string. Set to `'#FFFFFF'` by default.
 - `format`: *optional* string. Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).
+- `handleCents`: *optional* boolean. Set to `true` by default. Determines whether the supplied `goal` is divided by 100 (to display as dollars).
 - `i18n`: *optional* object containing localised text. Default i18n is:
 
   ```js

--- a/src/components/totals/Goal/__tests__/Goal-test.js
+++ b/src/components/totals/Goal/__tests__/Goal-test.js
@@ -47,11 +47,11 @@ describe('Goal', function() {
     var translation = {
       title: 'asdjasj',
       symbol: '£',
-      suffix: ' hours'
+      suffix: ' abc'
     };
 
     beforeEach(function() {
-      goal = <Goal goal="5000000" i18n={ translation } />;
+      goal = <Goal goal="50000" i18n={ translation } handleCents={ false } />;
       element = TestUtils.renderIntoDocument(goal);
     });
 
@@ -62,11 +62,11 @@ describe('Goal', function() {
       expect(title.getDOMNode().textContent).toBe(translation.title);
     });
 
-    it('check for a total with custom symbol and suffix', function() {
+    it('checks for a total with custom symbol and suffix', function() {
       element.setState({ isLoading: false });
       var total = findByClass(element, 'Goal__total');
 
-      expect(total.getDOMNode().textContent).toBe('£50 k hours');
+      expect(total.getDOMNode().textContent).toBe('£50 k abc');
     });
   });
 

--- a/src/components/totals/Goal/__tests__/Goal-test.js
+++ b/src/components/totals/Goal/__tests__/Goal-test.js
@@ -2,10 +2,11 @@
 jest.autoMockOff();
 
 describe('Goal', function() {
-  var React                       = require('react/addons');
-  var Goal                        = require('../');
-  var TestUtils                   = React.addons.TestUtils;
-  var findByClass                 = TestUtils.findRenderedDOMComponentWithClass;
+  var React       = require('react/addons');
+  var Goal        = require('../');
+  var TestUtils   = React.addons.TestUtils;
+  var findByClass = TestUtils.findRenderedDOMComponentWithClass;
+  var scryByClass = TestUtils.scryRenderedDOMComponentsWithClass;
 
   describe('Component defaults', function() {
     var goal;
@@ -36,7 +37,6 @@ describe('Goal', function() {
 
     it('renders an icon by default', function() {
       var icon = findByClass(element, 'Goal__icon');
-
       expect(icon).not.toBeNull();
     });
   });
@@ -46,7 +46,8 @@ describe('Goal', function() {
     var element;
     var translation = {
       title: 'asdjasj',
-      symbol: '£'
+      symbol: '£',
+      suffix: ' hours'
     };
 
     beforeEach(function() {
@@ -55,17 +56,17 @@ describe('Goal', function() {
     });
 
     it('renders a custom title', function() {
-      element.setState({isLoading: false});
+      element.setState({ isLoading: false });
       var title = findByClass(element, 'Goal__title');
 
       expect(title.getDOMNode().textContent).toBe(translation.title);
     });
 
-    it('check for a default total', function() {
-      element.setState({isLoading: false});
+    it('check for a total with custom symbol and suffix', function() {
+      element.setState({ isLoading: false });
       var total = findByClass(element, 'Goal__total');
 
-      expect(total.getDOMNode().textContent).toContain('£50 k');
+      expect(total.getDOMNode().textContent).toBe('£50 k hours');
     });
   });
 
@@ -84,6 +85,22 @@ describe('Goal', function() {
       var total = findByClass(element, 'Goal__total');
 
       expect(total.getDOMNode().textContent).toBe('$50,000.00');
+    });
+  });
+
+  describe('Displaying an icon', function() {
+    it('renders no icon when renderIcon set to false', function() {
+      var goal = <Goal goal="5000000" renderIcon={ false } />;
+      var element = TestUtils.renderIntoDocument(goal);
+      var icon = scryByClass(element, 'Goal__icon');
+      expect(icon.length).toEqual(0);
+    });
+
+    it('renders a custom icon when passed a valid FontAwesome string', function() {
+      var goal = <Goal goal="5000000" renderIcon="paw" />;
+      var element = TestUtils.renderIntoDocument(goal);
+      var icon = findByClass(element, 'fa-paw');
+      expect(icon).not.toBeNull();
     });
   });
 

--- a/src/components/totals/Goal/index.js
+++ b/src/components/totals/Goal/index.js
@@ -41,7 +41,7 @@ module.exports = React.createClass({
     var suffix = this.t('suffix');
     var goal   = this.props.goal;
 
-    if (this.props.handCents) goal = goal / 100;
+    if (this.props.handleCents) goal = goal / 100;
 
     var formattedTotal = symbol + numeral(goal).format(this.props.format);
 

--- a/src/components/totals/Goal/index.js
+++ b/src/components/totals/Goal/index.js
@@ -10,7 +10,7 @@ module.exports = React.createClass({
   displayName: "Goal",
   propTypes: {
     goal: React.PropTypes.string,
-    renderIcon: React.PropTypes.bool,
+    renderIcon: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.bool]),
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
     format: React.PropTypes.string,
@@ -27,20 +27,22 @@ module.exports = React.createClass({
       format: '0[.]00 a',
       defaultI18n: {
         title: 'Goal',
-        symbol: '$'
+        symbol: '$',
+        suffix: ''
       }
     };
   },
 
   renderTotal: function() {
-    var title = this.t('title');
-    var symbol = this.t('symbol');
-    var goal = this.props.goal / 100;
+    var title          = this.t('title');
+    var symbol         = this.t('symbol');
+    var suffix         = this.t('suffix');
+    var goal           = this.props.goal / 100;
     var formattedTotal = symbol + numeral(goal).format(this.props.format);
 
     return (
       <div>
-        <div className="Goal__total">{ formattedTotal }</div>
+        <div className="Goal__total">{ formattedTotal + suffix }</div>
         <div className="Goal__title">{ title }</div>
       </div>
     );
@@ -49,10 +51,12 @@ module.exports = React.createClass({
   renderIcon: function() {
     var renderIcon = this.props.renderIcon;
 
+    if (renderIcon === true) {
+      renderIcon = "dollar";
+    }
+
     if (renderIcon) {
-      return (
-        <Icon className="Goal__icon" icon="dollar"/>
-      );
+      return <Icon className="Goal__icon" icon={ renderIcon } />;
     }
   },
 

--- a/src/components/totals/Goal/index.js
+++ b/src/components/totals/Goal/index.js
@@ -14,7 +14,7 @@ module.exports = React.createClass({
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
     format: React.PropTypes.string,
-    centsToDollars: React.PropTypes.bool,
+    handleCents: React.PropTypes.bool,
     i18n: React.PropTypes.object
   },
 

--- a/src/components/totals/Goal/index.js
+++ b/src/components/totals/Goal/index.js
@@ -14,6 +14,7 @@ module.exports = React.createClass({
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
     format: React.PropTypes.string,
+    centsToDollars: React.PropTypes.bool,
     i18n: React.PropTypes.object
   },
 
@@ -25,6 +26,7 @@ module.exports = React.createClass({
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
       format: '0[.]00 a',
+      handleCents: true,
       defaultI18n: {
         title: 'Goal',
         symbol: '$',
@@ -34,10 +36,13 @@ module.exports = React.createClass({
   },
 
   renderTotal: function() {
-    var title          = this.t('title');
-    var symbol         = this.t('symbol');
-    var suffix         = this.t('suffix');
-    var goal           = this.props.goal / 100;
+    var title  = this.t('title');
+    var symbol = this.t('symbol');
+    var suffix = this.t('suffix');
+    var goal   = this.props.goal;
+
+    if (this.props.handCents) goal = goal / 100;
+
     var formattedTotal = symbol + numeral(goal).format(this.props.format);
 
     return (


### PR DESCRIPTION
These changes make the Goal component a little more generic. By default it still renders the goal as a dollar value, but now it can be used to display other types of goals: e.g. distance goal, hours goal, etc.

It also exposes the icon class name through renderIcon prop so the default can be overridden.