### PR TITLE
Update address lookup rate and styling

### DIFF
--- a/src/components/address/AddressLookup/index.js
+++ b/src/components/address/AddressLookup/index.js
@@ -117,16 +117,17 @@ module.exports = React.createClass({
   },
 
   setInput: function(input) {
-    if (input.length > 4) {
-      this.getList(input);
-    }
+    var chars = this.state.country === 'GB' ? 5 : 7;
     this.setState({
       focusOnMount: false,
-      loading: input.length > 4,
+      loading: false,
       input: input,
       error: null,
       addressList: null
     });
+    if (input.length >= chars) {
+      this.getList(input);
+    }
   },
 
   reset: function() {
@@ -178,7 +179,7 @@ module.exports = React.createClass({
       loading: true,
       cancelSearch: addressAPI.search(input, this.state.country, this.setList)
     });
-  }, 100, { trailing: true }),
+  }, 250, { trailing: true }),
 
   getAddress: function(id) {
     this.state.cancelFind();

--- a/src/components/forms/Input/style.scss
+++ b/src/components/forms/Input/style.scss
@@ -4,7 +4,7 @@
   z-index: 1;
   width: 100%;
   text-align: left;
-  padding-bottom: $x-5;
+  margin-bottom: $x-5;
   font-family: $ehw-sans-serif-fonts;
 }
 
@@ -115,5 +115,5 @@
 
 .Input--wide + .Input--narrow { margin-left: 2%; }
 
-.Input--tight { padding-bottom: $x-2; }
-.Input--loose { padding-bottom: $x-9; }
+.Input--tight { margin-bottom: $x-2; }
+.Input--loose { margin-bottom: $x-9; }


### PR DESCRIPTION
AddressLookup now requires minimum 5 chars for GB and 7 for elsewhere before looking up a postcode/address.  The debounce rate has been increased from 100ms to 250ms as well.