### PR TITLE
Reduce jsonp default timeout to 20 secs

### DIFF
--- a/src/lib/getJSONP.js
+++ b/src/lib/getJSONP.js
@@ -1,9 +1,10 @@
 "use strict";
 
 var jsonp = require('jsonp');
+var DEFAULT_TIMEOUT = 20000;
 
 function getJSONP(url, callback) {
-  return jsonp(url, {}, function(error, data) {
+  return jsonp(url, {timeout: DEFAULT_TIMEOUT}, function(error, data) {
     callback(error ? null : data);
   });
 }


### PR DESCRIPTION
Because 60 secs is an eternity
