### PR TITLE
Ensure correct ordering of returned charities

### DIFF
--- a/src/components/charities/PromoCharities/__tests__/PromoCharities-test.js
+++ b/src/components/charities/PromoCharities/__tests__/PromoCharities-test.js
@@ -12,7 +12,7 @@ describe('PromoCharities', function() {
   describe('default behaviour for PromoCharities', function() {
     var promoCharities;
     var element;
-    var tabsData = [{category: 'Tab One', charityUids: ['au-1']}];
+    var tabsData = [{ category: 'Tab One', charityUids: ['au-1'] }];
 
     beforeEach(function() {
       promoCharities = <PromoCharities action="fundraise" tabs={ tabsData } />;
@@ -52,12 +52,42 @@ describe('PromoCharities', function() {
     });
 
     it('renders a custom heading and subheading', function() {
-      element.setState({isLoading: false});
+      element.setState({ isLoading: false });
       var heading = findByClass(element, 'PromoCharities__heading');
       var subHeading  = findByClass(element, 'PromoCharities__subheading');
 
       expect(heading.getDOMNode().textContent).toBe(translation.heading);
       expect(subHeading.getDOMNode().textContent).toBe(translation.subheading);
+    });
+  });
+
+  describe('Order of rendered items matches order of supplied uids', function() {
+    var promoCharities;
+    var element;
+    var tabsData = [{ category: 'Tab One', charityUids: ['au-1','au-2','au-3'] }];
+    var keys = tabsData[0].charityUids;
+
+    var charities = [
+      { name: 'charity3', id: 'au-3' },
+      { name: 'charity1', id: 'au-1' },
+      { name: 'charity2', id: 'au-2' }
+    ];
+
+    beforeEach(function() {
+      promoCharities = <PromoCharities action="fundraise" tabs={ tabsData } />;
+      element = TestUtils.renderIntoDocument(promoCharities);
+    });
+
+    it('re-orders an array of charities to match the order of uids passed in', function() {
+      element.setState({ isLoading: false });
+
+      var reordered = [
+        { name: 'charity1', id: 'au-1' },
+        { name: 'charity2', id: 'au-2' },
+        { name: 'charity3', id: 'au-3' }
+      ];
+
+      expect(element.orderCharities(charities, keys)).toEqual(reordered);
     });
   });
 });

--- a/src/components/charities/PromoCharities/__tests__/PromoCharities-test.js
+++ b/src/components/charities/PromoCharities/__tests__/PromoCharities-test.js
@@ -79,8 +79,6 @@ describe('PromoCharities', function() {
     });
 
     it('re-orders an array of charities to match the order of uids passed in', function() {
-      element.setState({ isLoading: false });
-
       var reordered = [
         { name: 'charity1', id: 'au-1' },
         { name: 'charity2', id: 'au-2' },

--- a/src/components/charities/PromoCharities/index.js
+++ b/src/components/charities/PromoCharities/index.js
@@ -55,10 +55,20 @@ module.exports = React.createClass({
   },
 
   tabLoaded: function(tabIndex, charities) {
+    var keys = this.props.tabs[tabIndex].charityUids;
     var tabs = this.state.tabs;
     var tab  = tabs[tabIndex];
-    var keys = this.props.tabs[tabIndex].charityUids;
 
+    tab.isLoaded = true;
+    tab.contents = this.orderCharities(charities, keys);
+
+    this.setState({
+      isLoaded: _.every(tabs, 'isLoaded'),
+      tabs: tabs
+    });
+  },
+
+  orderCharities: function(charities, keys) {
     var tempObj = {};
 
     _.forEach(charities, function(charity) {
@@ -69,15 +79,7 @@ module.exports = React.createClass({
       charities[i] = tempObj[key];
     });
 
-    tempObj = undefined;
-
-    tab.isLoaded = true;
-    tab.contents = charities;
-
-    this.setState({
-      isLoaded: _.every(tabs, 'isLoaded'),
-      tabs: tabs
-    });
+    return charities;
   },
 
   selectHandler: function(charity) {

--- a/src/components/charities/PromoCharities/index.js
+++ b/src/components/charities/PromoCharities/index.js
@@ -57,6 +57,19 @@ module.exports = React.createClass({
   tabLoaded: function(tabIndex, charities) {
     var tabs = this.state.tabs;
     var tab  = tabs[tabIndex];
+    var keys = this.props.tabs[tabIndex].charityUids;
+
+    var tempObj = {};
+
+    _.forEach(charities, function(charity) {
+      tempObj[charity.id] = charity;
+    });
+
+    _.forEach(keys, function(key, i) {
+      charities[i] = tempObj[key];
+    });
+
+    tempObj = undefined;
 
     tab.isLoaded = true;
     tab.contents = charities;

--- a/src/components/charities/PromoCharities/index.js
+++ b/src/components/charities/PromoCharities/index.js
@@ -36,7 +36,6 @@ module.exports = React.createClass({
   componentWillMount: function() {
     var tabs = _.map(this.props.tabs, function(tab, tabIndex) {
       var data = {
-        isLoading: true,
         tabName: tab.category,
         contents: []
       };


### PR DESCRIPTION
This makes sure that the PromotedCharities component renders charities in the order that they are passed in via the tabs prop.

Somewhat of a work-around given the charities API endpoint currently seems to return charities objects in random order.