### PR TITLE
Fix uk min postcode chars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "EverydayHero <edh-dev@everydayhero.com>",
   "name": "edh-widgets",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Widgets are small Javascript components that integrate with EverydayHero's API. These include search components and components for showing leaderboard and fundraising totals for campaigns, charities, and networks. Unlike iframe snippets, using widgets allows you to customise the base-level styling to suit your needs.",
   "license": "MIT",
   "main": "src/widgets.js",

--- a/src/components/address/AddressLookup/__tests__/AddressLookup-test.js
+++ b/src/components/address/AddressLookup/__tests__/AddressLookup-test.js
@@ -67,6 +67,26 @@ describe('AddressLookup', function() {
     expect(locality.value).toBe('Sydney');
   });
 
+  it('UK postcode search requires at least 5 chars', function() {
+    var element = TestUtils.renderIntoDocument(<AddressLookup country="GB"/>);
+    var input = findByClass(element, 'Input__input').getDOMNode();
+    TestUtils.Simulate.change(input, { target: { value: "1234" } });
+    expect(address.search).not.toBeCalled();
+
+    TestUtils.Simulate.change(input, { target: { value: "12345" } });
+    expect(address.search).lastCalledWith('12345', 'GB', jasmine.any(Function));
+  });
+
+  it('Address search requires at least 7 chars', function() {
+    var element = TestUtils.renderIntoDocument(<AddressLookup country="US"/>);
+    var input = findByClass(element, 'Input__input').getDOMNode();
+    TestUtils.Simulate.change(input, { target: { value: "123456" } });
+    expect(address.search).not.toBeCalled();
+
+    TestUtils.Simulate.change(input, { target: { value: "1234567" } });
+    expect(address.search).lastCalledWith('1234567', 'US', jasmine.any(Function));
+  });
+
   it('returns a list of addresses', function() {
     var element = TestUtils.renderIntoDocument(<AddressLookup />);
     var input = findByClass(element, 'Input__input').getDOMNode();
@@ -103,7 +123,6 @@ describe('AddressLookup', function() {
 
   describe('selected address', function() {
     var element, listItem, callback, validate;
-
 
     beforeEach(function() {
       address.find.mockClear();

--- a/src/components/address/AddressLookup/index.js
+++ b/src/components/address/AddressLookup/index.js
@@ -182,7 +182,7 @@ module.exports = React.createClass({
   },
 
   getList: _.debounce(function(input) {
-    var chars = this.state.country === 'GB' ? 5 : 7;
+    var chars = this.state.country.iso === 'GB' ? 5 : 7;
     this.state.cancelSearch();
     if (input.length >= chars) {
       this.setState({


### PR DESCRIPTION
Not sure why this was working and now it's not, but it should require 5 chars, not 7.
Have added widget address lookup tests to ensure this doesn't happen again.