### PR TITLE
Fix style bugs.

### DIFF
--- a/src/components/totals/GoalProgress/style.scss
+++ b/src/components/totals/GoalProgress/style.scss
@@ -13,6 +13,7 @@ $ehw-animation-speed: 200ms;
   );
   background-color: #D0D0D0;
   color: #FFFFFF;
+  overflow: hidden;
 }
 
 /* edit pattern at http://ptrn.it/1x0nFEh */
@@ -23,12 +24,18 @@ $ehw-animation-speed: 200ms;
   width: $x-9;
   text-align: center;
   border-left: solid white 2px;
+  position: relative;
 }
 
 .GoalProgress__area {
   position: relative;
   text-align: right;
   display: table-cell;
+}
+
+.GoalProgress__bar,
+.GoalProgress__barTable {
+  height: 100%;
 }
 
 .GoalProgress__bar,
@@ -43,7 +50,6 @@ $ehw-animation-speed: 200ms;
 
 .GoalProgress__barTable {
   display: table;
-  height: 40px;
 }
 
 .GoalProgress__barFill {


### PR DESCRIPTION
Just fixing some minor style issues:



The goal progress was height was off by a few pixels, example: 
![screen shot 2015-03-18 at 11 06 47 pm](https://cloud.githubusercontent.com/assets/859298/6709405/dbcc9346-cdc4-11e4-8e19-c9199d242aa6.png)

I set to just be 100% so it's always right (rather than static px value):

![screen shot 2015-03-18 at 11 14 33 pm](https://cloud.githubusercontent.com/assets/859298/6709411/e98f7f2a-cdc4-11e4-944a-d36eb3b17df5.png)


If the fundraising goal was exceeded the bar was travelling outside the component container, also the trophy icon was being hidden beneath. Example:

![screen shot 2015-03-18 at 11 12 19 pm](https://cloud.githubusercontent.com/assets/859298/6709469/4cb5cdb6-cdc5-11e4-894f-3658b10071db.png)


Fixed:

![screen shot 2015-03-18 at 11 14 00 pm](https://cloud.githubusercontent.com/assets/859298/6709456/305c7ed0-cdc5-11e4-9ab4-93520cb2ac69.png)