### PR TITLE
Se update leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,8 +602,8 @@ Displays an individuals leaderboard sorted by funds raised (highest first) for a
 - `country`: *optional* string country code of region, either 'au', 'ie', 'nz', 'uk' or 'us'. Required by `campaignSlug` and `charitySlug`.
 - `limit`: *optional* number. Set to `24` by default. Determines how many results are returned in total.
 - `pageSize`: *optional* number. Set to `12` by default. Determines how many results to show per page.
-- `backgroundColor`: *optional* string. Set to `'#EBEBEB'` by default.
-- `textColor`: *optional* string. Set to `'#333333'` by default.
+- `backgroundColor`: *optional* string. Accepts a hex value. Not set by default.
+- `textColor`: *optional* string. Accepts a hex value. Not set by default.
 - `childWidth`: *optional* number. Set to `250` by default. Sets the minimum width for leaderboard items to display.
 - `currencyFormat`: *optional* string. Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).
 - `i18n`: *optional* object containing localised text. Default i18n is:
@@ -648,8 +648,8 @@ Displays a team leaderboard sorted by funds raised (highest first) for a campaig
 - `country`: *optional* string country code of region, either 'au', 'ie', 'nz', 'uk' or 'us'. Required by `campaignSlug` and `charitySlug`.
 - `limit`: *optional* number. Set to `24` by default. Determines how many results are returned in total.
 - `pageSize`: *optional* number. Set to `12` by default. Determines how many results to show per page.
-- `backgroundColor`: *optional* string. Set to `'#EBEBEB'` by default.
-- `textColor`: *optional* string. Set to `'#333333'` by default.
+- `backgroundColor`: *optional* string. Accepts a hex value. Not set by default.
+- `textColor`: *optional* string. Accepts a hex value. Not set by default.
 - `childWidth`: *optional* number. Set to `250` by default. Sets the minimum width for leaderboard items to display.
 - `altTemplate`: *optional* boolean. Set to `false` by default. Renders an alternate template set when set to `true`.
 - `currencyFormat`: *optional* string. Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Displays a set of fundraiser profile images (that have a page) for a single spec
 
 #### Leaderboard
 
-Displays a leaderboard sorted by funds raised (highest first) for a campaign or charity. Can be set to show leaderboards for teams or individuals.
+Displays an individuals leaderboard sorted by funds raised (highest first) for a campaign or charity.
 
 ##### Options
 
@@ -600,21 +600,18 @@ Displays a leaderboard sorted by funds raised (highest first) for a campaign or 
 - `charityUid`: *optional* string charity uid to filter results by charity.
 - `charitySlug`: *optional* string charity slug to filter results by charity. Requires `country`.
 - `country`: *optional* string country code of region, either 'au', 'ie', 'nz', 'uk' or 'us'. Required by `campaignSlug` and `charitySlug`.
-- `type`: *optional* string. Set a type of either `'team'` or `'individual'`. Set to `'individual'` by default.
 - `limit`: *optional* number. Set to `24` by default. Determines how many results are returned in total.
 - `pageSize`: *optional* number. Set to `12` by default. Determines how many results to show per page.
 - `backgroundColor`: *optional* string. Set to `'#EBEBEB'` by default.
 - `textColor`: *optional* string. Set to `'#333333'` by default.
+- `childWidth`: *optional* number. Set to `250` by default. Sets the minimum width for leaderboard items to display.
 - `currencyFormat`: *optional* string. Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).
 - `i18n`: *optional* object containing localised text. Default i18n is:
 
   ```js
   {
-    raisedTitle: 'Raised',
-    membersTitle: 'Members',
-    rankTitle: 'Ranked',
     symbol: '$',
-    heading: 'Leaderboard > Top Individuals'
+    heading: 'Top Individuals'
   }
   ```
 
@@ -633,6 +630,55 @@ Displays a leaderboard sorted by funds raised (highest first) for a campaign or 
     <div id="LeaderboardExample">Loading...</div>
     <script>
       edh.widgets.renderWidget('LeaderboardExample', 'Leaderboard', { campaignUid: 'us-0' });
+    </script>
+  </body>
+</html>
+```
+
+#### Team Leaderboard
+
+Displays a team leaderboard sorted by funds raised (highest first) for a campaign or charity.
+
+##### Options
+
+- `campaignUid`: *optional* string campaign uid to filter results by campaign.
+- `campaignSlug`: *optional* string campaign slug to filter results by campaign. Requires `country`.
+- `charityUid`: *optional* string charity uid to filter results by charity.
+- `charitySlug`: *optional* string charity slug to filter results by charity. Requires `country`.
+- `country`: *optional* string country code of region, either 'au', 'ie', 'nz', 'uk' or 'us'. Required by `campaignSlug` and `charitySlug`.
+- `limit`: *optional* number. Set to `24` by default. Determines how many results are returned in total.
+- `pageSize`: *optional* number. Set to `12` by default. Determines how many results to show per page.
+- `backgroundColor`: *optional* string. Set to `'#EBEBEB'` by default.
+- `textColor`: *optional* string. Set to `'#333333'` by default.
+- `childWidth`: *optional* number. Set to `250` by default. Sets the minimum width for leaderboard items to display.
+- `altTemplate`: *optional* boolean. Set to `false` by default. Renders an alternate template set when set to `true`.
+- `currencyFormat`: *optional* string. Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).
+- `i18n`: *optional* object containing localised text. Default i18n is:
+
+  ```js
+  {
+    raisedTitle: 'Raised',
+    membersTitle: 'Members',
+    symbol: '$',
+    heading: 'Top Teams'
+  }
+  ```
+
+##### Example
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+    <link href="//d1ig6folwd6a9s.cloudfront.net/widgets-[0.0.0].css" rel="stylesheet">
+    <script src="//d1ig6folwd6a9s.cloudfront.net/widgets-[0.0.0].js"></script>
+  </head>
+  <body>
+    <div id="TeamLeaderboardExample">Loading...</div>
+    <script>
+      edh.widgets.renderWidget('TeamLeaderboardExample', 'TeamLeaderboard', { campaignUid: 'us-0' });
     </script>
   </body>
 </html>

--- a/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
+++ b/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
@@ -27,7 +27,7 @@ describe('Leaderboard', function() {
     it('renders a default heading', function() {
       var heading = findByClass(element, 'Leaderboard__heading');
 
-      expect(heading.getDOMNode().textContent).toBe('Leaderboard > Top Individuals');
+      expect(heading.getDOMNode().textContent).toBe('Top Individuals');
     });
 
     it('renders a loading icon', function() {
@@ -98,11 +98,11 @@ describe('Leaderboard', function() {
   });
 
   describe('Number formatting options', function() {
-    it('renders in a short format by default', function() {
+    it('renders in a long format with commas by default', function() {
       var leaderboard = <Leaderboard campaignUid="au-0" />;
       var element = TestUtils.renderIntoDocument(leaderboard);
 
-      expect(element.formatAmount(10000)).toEqual('$100 ');
+      expect(element.formatAmount(100000)).toEqual('$1,000');
     });
 
     it('renders a different format if given acceptable numeral.js string', function() {

--- a/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
+++ b/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
@@ -44,7 +44,7 @@ describe('Leaderboard', function() {
     };
 
     beforeEach(function() {
-      leaderboard = <Leaderboard campaignUid="au-0" i18n={ translation } type="team" />;
+      leaderboard = <Leaderboard campaignUid="au-0" i18n={ translation } />;
       element = TestUtils.renderIntoDocument(leaderboard);
     });
 

--- a/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
+++ b/src/components/leaderboards/Leaderboard/__tests__/Leaderboard-test.js
@@ -3,13 +3,13 @@ jest.autoMockOff();
 jest.mock('../../../../api/campaigns');
 
 describe('Leaderboard', function() {
-  var _               = require('lodash');
-  var React           = require('react/addons');
-  var Leaderboard     = require('../');
-  var LeaderboardItem = require('../../LeaderboardItem/');
-  var TestUtils       = React.addons.TestUtils;
-  var findByClass     = TestUtils.findRenderedDOMComponentWithClass;
-  var scryByClass     = TestUtils.scryRenderedDOMComponentsWithClass;
+  var _                 = require('lodash');
+  var React             = require('react/addons');
+  var Leaderboard       = require('../');
+  var LeaderboardItem   = require('../../LeaderboardItem/');
+  var LeaderboardPaging = require('../../LeaderboardPaging/');
+  var TestUtils         = React.addons.TestUtils;
+  var findByClass       = TestUtils.findRenderedDOMComponentWithClass;
 
   describe('Component defaults', function() {
     var leaderboard;
@@ -110,6 +110,28 @@ describe('Leaderboard', function() {
       var element = TestUtils.renderIntoDocument(leaderboard);
 
       expect(element.formatAmount(10000)).toEqual('$100.00');
+    });
+  });
+
+  describe('paging button rendering', function() {
+    it('renders a paging component if multiple pages are available', function() {
+      var leaderboard = <Leaderboard campaignUid="au-0" limit={ 10 } pageSize={ 5 } />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+      element.setState({ isLoading: false });
+
+      var paging = <LeaderboardPaging />;
+      var pagingFunction = element.renderPaging();
+      expect(pagingFunction).toBeDefined();
+    });
+
+    it('does not render a paging component if only 1 page is available', function() {
+      var leaderboard = <Leaderboard campaignUid="au-0" limit={ 5 } pageSize={ 5 } />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+      element.setState({ isLoading: false });
+
+      var paging = <LeaderboardPaging />;
+      var pagingFunction = element.renderPaging();
+      expect(pagingFunction).toBeUndefined();
     });
   });
 });

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -58,6 +58,7 @@ module.exports = React.createClass({
 
   componentDidMount: function() {
     addEventListener(window, 'resize', this.setChildWidth);
+    this.setChildWidth();
   },
 
   componentWillUnmount: function() {
@@ -68,7 +69,7 @@ module.exports = React.createClass({
     this.setState({
       childWidth: this.getChildrenWidth(this.props.childWidth, this.props.pageSize)
     });
-  }, 100),
+  }, 100, { trailing: true }),
 
   renderLeaderboardItems: function() {
     if (this.state.isLoading) {

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -21,7 +21,7 @@ module.exports = React.createClass({
     charitySlug: React.PropTypes.string,
     charityUid: React.PropTypes.string,
     country: React.PropTypes.oneOf(['au', 'ie', 'nz', 'uk', 'us']),
-    type: React.PropTypes.oneOf(['team', 'individual']),
+    type: React.PropTypes.oneOf(['individual']),
     limit: React.PropTypes.number,
     pageSize: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -26,6 +26,7 @@ module.exports = React.createClass({
     pageSize: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
+    childWidth: React.PropTypes.number,
     currencyFormat: React.PropTypes.string,
     i18n: React.PropTypes.object
   },
@@ -40,8 +41,6 @@ module.exports = React.createClass({
       childWidth: 250,
       currencyFormat: '0,0[.]00',
       defaultI18n: {
-        raisedTitle: 'Raised',
-        membersTitle: 'Members',
         symbol: '$',
         heading: 'Top Individuals'
       }

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -4,6 +4,7 @@ var _                   = require('lodash');
 var React               = require('react');
 var cx                  = require('react/lib/cx');
 var I18nMixin           = require('../../mixins/I18n');
+var DOMInfoMixin        = require('../../mixins/DOMInfo');
 var campaigns           = require('../../../api/campaigns');
 var charities           = require('../../../api/charities');
 var pages               = require('../../../api/pages');
@@ -11,9 +12,11 @@ var Icon                = require('../../helpers/Icon');
 var TeamLeaderboardItem = require('../TeamLeaderboardItem');
 var LeaderboardItem     = require('../LeaderboardItem');
 var numeral             = require('numeral');
+var addEventListener    = require('../../../lib/addEventListener');
+var removeEventListener = require('../../../lib/removeEventListener');
 
 module.exports = React.createClass({
-  mixins: [I18nMixin],
+  mixins: [I18nMixin, DOMInfoMixin],
   displayName: "Leaderboard",
   propTypes: {
     campaignSlug: React.PropTypes.string,
@@ -51,13 +54,28 @@ module.exports = React.createClass({
     return {
       isLoading: false,
       boardData: [],
-      currentPage: 1
+      currentPage: 1,
+      itemWidth: '',
     };
   },
 
   componentWillMount: function() {
     this.loadLeaderboard();
   },
+
+  componentDidMount: function() {
+    addEventListener(window, 'resize', this.setItemWidth);
+  },
+
+  componentWillUnmount: function() {
+    removeEventListener(window, 'resize', this.setItemWidth);
+  },
+
+  setItemWidth: _.debounce(function() {
+    this.setState({
+      itemWidth: this.getChildrenWidth(250, this.props.pageSize)
+    });
+  }, 100),
 
   getEndpoint: function() {
     var endpoint;
@@ -180,7 +198,8 @@ module.exports = React.createClass({
           url={ d.url }
           isoCode={ d.isoCode }
           amount={ formattedAmount }
-          imgSrc={ d.medImgSrc } />
+          imgSrc={ d.medImgSrc }
+          width={ this.state.itemWidth } />
       );
 
     }, this);

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -1,15 +1,16 @@
 "use strict";
 
-var _                   = require('lodash');
-var React               = require('react');
-var I18nMixin           = require('../../mixins/I18n');
-var DOMInfoMixin        = require('../../mixins/DOMInfo');
-var LeaderboardMixin    = require('../../mixins/Leaderboard');
-var Icon                = require('../../helpers/Icon');
-var LeaderboardItem     = require('../LeaderboardItem');
-var numeral             = require('numeral');
-var addEventListener    = require('../../../lib/addEventListener');
-var removeEventListener = require('../../../lib/removeEventListener');
+var _                       = require('lodash');
+var React                   = require('react/addons');
+var I18nMixin               = require('../../mixins/I18n');
+var DOMInfoMixin            = require('../../mixins/DOMInfo');
+var LeaderboardMixin        = require('../../mixins/Leaderboard');
+var Icon                    = require('../../helpers/Icon');
+var LeaderboardItem         = require('../LeaderboardItem');
+var numeral                 = require('numeral');
+var addEventListener        = require('../../../lib/addEventListener');
+var removeEventListener     = require('../../../lib/removeEventListener');
+var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 
 module.exports = React.createClass({
   mixins: [I18nMixin, DOMInfoMixin, LeaderboardMixin],
@@ -52,21 +53,21 @@ module.exports = React.createClass({
       isLoading: false,
       boardData: [],
       currentPage: 1,
-      itemWidth: this.props.childWidth,
+      childWidth: this.props.childWidth,
     };
   },
 
   componentDidMount: function() {
-    addEventListener(window, 'resize', this.setItemWidth);
+    addEventListener(window, 'resize', this.setChildWidth);
   },
 
   componentWillUnmount: function() {
-    removeEventListener(window, 'resize', this.setItemWidth);
+    removeEventListener(window, 'resize', this.setChildWidth);
   },
 
-  setItemWidth: _.debounce(function() {
+  setChildWidth: _.debounce(function() {
     this.setState({
-      itemWidth: this.getChildrenWidth(this.props.childWidth, this.props.pageSize)
+      childWidth: this.getChildrenWidth(this.props.childWidth, this.props.pageSize)
     });
   }, 100),
 
@@ -95,7 +96,7 @@ module.exports = React.createClass({
           isoCode={ d.isoCode }
           amount={ formattedAmount }
           imgSrc={ d.medImgSrc }
-          width={ this.state.itemWidth } />
+          width={ this.state.childWidth } />
       );
 
     }, this);
@@ -112,7 +113,9 @@ module.exports = React.createClass({
       <div className="Leaderboard" style={ customStyle }>
         <h3 className="Leaderboard__heading">{ heading }</h3>
         <ol className="Leaderboard__items">
-          { this.renderLeaderboardItems() }
+          <ReactCSSTransitionGroup transitionName="Leaderboard__animation" component="div">
+            { this.renderLeaderboardItems() }
+          </ReactCSSTransitionGroup>
         </ol>
         { this.renderPaging() }
       </div>

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -2,6 +2,7 @@
 
 var _                   = require('lodash');
 var React               = require('react');
+var cx                  = require('react/lib/cx');
 var I18nMixin           = require('../../mixins/I18n');
 var campaigns           = require('../../../api/campaigns');
 var charities           = require('../../../api/charities');
@@ -32,17 +33,16 @@ module.exports = React.createClass({
   getDefaultProps: function() {
     return {
       type: 'individual',
-      limit: 24,
+      limit: 48,
       pageSize: 12,
       backgroundColor: '#525252',
       textColor: '#FFFFFF',
-      currencyFormat: '0[.]00 a',
+      currencyFormat: '0,0[.]00',
       defaultI18n: {
         raisedTitle: 'Raised',
         membersTitle: 'Members',
-        rankTitle: 'Ranked',
         symbol: '$',
-        heading: 'Leaderboard > Top Individuals'
+        heading: 'Top Individuals'
       }
     };
   },
@@ -61,8 +61,8 @@ module.exports = React.createClass({
 
   getEndpoint: function() {
     var endpoint;
-
     var props = this.props;
+
     if (props.country) {
       if (props.campaignSlug) { endpoint = campaigns.leaderboardBySlug.bind(campaigns, props.country, props.campaignSlug); }
       if (props.charitySlug)  { endpoint = charities.leaderboardBySlug.bind(charities, props.country, props.charitySlug); }
@@ -176,7 +176,6 @@ module.exports = React.createClass({
         <LeaderboardItem
           key={ d.id }
           rank={ formattedRank }
-          rankTitle={ this.t('rankTitle') }
           name={ d.name }
           url={ d.url }
           isoCode={ d.isoCode }
@@ -232,6 +231,35 @@ module.exports = React.createClass({
     }
   },
 
+  renderPrevBtn: function() {
+    var classes = cx({
+      "Leaderboard__prevBtn": true,
+      "Leaderboard__prevBtn--active": this.state.currentPage > 1
+    });
+
+    return (
+      <div onClick={ this.prevPage } className={ classes }>
+        <Icon className="Leaderboard__icon" icon="caret-left"/>
+      </div>
+    );
+  },
+
+  renderNextBtn: function() {
+    var pageCount = this.props.limit / this.props.pageSize;
+    var currentPage = this.state.currentPage;
+
+    var classes = cx({
+      "Leaderboard__nextBtn": true,
+      "Leaderboard__nextBtn--active": currentPage < pageCount
+    });
+
+    return (
+      <div onClick={ this.nextPage } className={ classes }>
+        <Icon className="Leaderboard__icon" icon="caret-right"/>
+      </div>
+    );
+  },
+
   render: function() {
     var limit       = this.props.limit;
     var pageSize    = this.props.pageSize;
@@ -242,6 +270,7 @@ module.exports = React.createClass({
     };
     var pageControls;
 
+
     if (limit > pageSize) {
       pageControls = (
         <div className="Leaderboard__controller">
@@ -249,12 +278,8 @@ module.exports = React.createClass({
             { this.renderIndicators() }
           </div>
           <div className="Leaderboard__controls">
-            <div onClick={ this.prevPage } className="Leaderboard__prevBtn">
-              <Icon className="Leaderboard__icon" icon="caret-left"/>
-            </div>
-            <div onClick={ this.nextPage } className="Leaderboard__nextBtn">
-              <Icon className="Leaderboard__icon" icon="caret-right"/>
-            </div>
+            { this.renderPrevBtn() }
+            { this.renderNextBtn() }
           </div>
         </div>
       );

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -21,7 +21,6 @@ module.exports = React.createClass({
     charitySlug: React.PropTypes.string,
     charityUid: React.PropTypes.string,
     country: React.PropTypes.oneOf(['au', 'ie', 'nz', 'uk', 'us']),
-    type: React.PropTypes.oneOf(['individual']),
     limit: React.PropTypes.number,
     pageSize: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
@@ -33,7 +32,6 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
-      type: 'individual',
       limit: 48,
       pageSize: 12,
       backgroundColor: null,
@@ -54,6 +52,10 @@ module.exports = React.createClass({
       currentPage: 1,
       childWidth: this.props.childWidth,
     };
+  },
+
+  componentWillMount: function() {
+    this.loadLeaderboard('individual');
   },
 
   componentDidMount: function() {

--- a/src/components/leaderboards/Leaderboard/style.scss
+++ b/src/components/leaderboards/Leaderboard/style.scss
@@ -25,7 +25,7 @@
 
 .Leaderboard__animation-enter {
   opacity: 0.01;
-  transition: opacity .66s ease-in;
+  transition: opacity .6s ease-in;
 }
 
 .Leaderboard__animation-enter-active {

--- a/src/components/leaderboards/Leaderboard/style.scss
+++ b/src/components/leaderboards/Leaderboard/style.scss
@@ -21,3 +21,21 @@
     @extend %ehw-tile-loading-icon;
   }
 }
+
+.Leaderboard__animation-enter {
+  opacity: 0.01;
+  transition: opacity .66s ease-in;
+}
+
+.Leaderboard__animation-enter-active {
+  opacity: 1;
+}
+
+// pull existing items out of view immediately
+.Leaderboard__animation-leave {
+  position: absolute;
+  top: -999px;
+  left: -999px;
+  opacity: 0;
+  transition: all .1s ease-in;
+}

--- a/src/components/leaderboards/Leaderboard/style.scss
+++ b/src/components/leaderboards/Leaderboard/style.scss
@@ -4,6 +4,7 @@
   font-family: $ehw-sans-serif-fonts;
   font-size: $ehw-default-font-size;
   color: #fff;
+  padding: 0 0 $x-2;
 
   .Leaderboard__heading {
     @extend %ehw-tile-heading;

--- a/src/components/leaderboards/Leaderboard/style.scss
+++ b/src/components/leaderboards/Leaderboard/style.scss
@@ -7,6 +7,7 @@
 
   .Leaderboard__heading {
     @extend %ehw-tile-heading;
+    text-align: center;
   }
 
   .Leaderboard__items {
@@ -35,6 +36,12 @@
     padding: 5px;
     cursor: pointer;
     font-size: $x-6;
+    opacity: 0.5;
+  }
+
+  .Leaderboard__prevBtn--active,
+  .Leaderboard__nextBtn--active {
+    opacity: 1;
   }
 
   .Leaderboard__indicator {

--- a/src/components/leaderboards/LeaderboardItem/index.js
+++ b/src/components/leaderboards/LeaderboardItem/index.js
@@ -5,9 +5,23 @@ var React = require('react');
 module.exports = React.createClass({
   displayName: 'LeaderboardItem',
 
+  propTypes: {
+    rank: React.PropTypes.string,
+    imgSrc: React.PropTypes.string.isRequired,
+    url: React.PropTypes.string.isRequired,
+    name: React.PropTypes.string.isRequired,
+    isoCode: React.PropTypes.string.isRequired,
+    amount: React.PropTypes.string.isRequired,
+    width: React.PropTypes.string.isRequired
+  },
+
   render: function() {
+    var style = {
+      width: this.props.width
+    };
+
     return (
-      <div className="LeaderboardItem">
+      <div className="LeaderboardItem" style={ style }>
         <div className="LeaderboardItem__skin">
           <a href={ this.props.url } className="LeaderboardItem__image">
             <img src={ this.props.imgSrc } />

--- a/src/components/leaderboards/LeaderboardItem/index.js
+++ b/src/components/leaderboards/LeaderboardItem/index.js
@@ -1,32 +1,30 @@
 "use strict";
 
-var React         = require('react');
+var React = require('react');
 
 module.exports = React.createClass({
   displayName: 'LeaderboardItem',
 
   render: function() {
     return (
-      <li className="LeaderboardItem">
+      <div className="LeaderboardItem">
         <div className="LeaderboardItem__skin">
           <a href={ this.props.url } className="LeaderboardItem__image">
             <img src={ this.props.imgSrc } />
           </a>
           <div className="LeaderboardItem__content">
-            <div className="LeaderboardItem__details">
-              <div className="LeaderboardItem__name">
-                { this.props.name }
-              </div>
-              <div className="LeaderboardItem__rank">
-                { this.props.rankTitle + ' ' + this.props.rank }
-              </div>
+            <div className="LeaderboardItem__name">
+              { this.props.name }
             </div>
             <div className="LeaderboardItem__amount">
               { this.props.amount }
             </div>
           </div>
+          <div className="LeaderboardItem__rank">
+            { this.props.rank }
+          </div>
         </div>
-      </li>
+      </div>
     );
   }
 });

--- a/src/components/leaderboards/LeaderboardItem/style.scss
+++ b/src/components/leaderboards/LeaderboardItem/style.scss
@@ -2,7 +2,6 @@
   box-sizing: border-box;
   display: block;
   padding: $x-1;
-  // width: 33.33%;
   float: left;
   position: relative;
 

--- a/src/components/leaderboards/LeaderboardItem/style.scss
+++ b/src/components/leaderboards/LeaderboardItem/style.scss
@@ -3,8 +3,7 @@
   display: block;
   padding: $x-1;
   width: 33.33%;
-  // float: left;
-  display: inline-block;
+  float: left;
   position: relative;
 
   @include media-max($breakpoint-xl) {

--- a/src/components/leaderboards/LeaderboardItem/style.scss
+++ b/src/components/leaderboards/LeaderboardItem/style.scss
@@ -2,7 +2,7 @@
   box-sizing: border-box;
   display: block;
   padding: $x-1;
-  width: 33.33%;
+  // width: 33.33%;
   float: left;
   position: relative;
 

--- a/src/components/leaderboards/LeaderboardItem/style.scss
+++ b/src/components/leaderboards/LeaderboardItem/style.scss
@@ -1,9 +1,10 @@
 .LeaderboardItem {
   box-sizing: border-box;
   display: block;
-  padding: 0 10px 15px;
+  padding: $x-1;
   width: 33.33%;
-  float: left;
+  // float: left;
+  display: inline-block;
   position: relative;
 
   @include media-max($breakpoint-xl) {
@@ -12,7 +13,7 @@
 
   @include media-max($breakpoint-s) {
     width: 100%;
-    padding: 2px 10px 0;
+    padding: $x-1 $x-2 0;
   }
 }
 
@@ -21,26 +22,13 @@
   background: #fff;
   color: $ehw-grey-dark;
   border-radius: $ehw-border-radius;
+  position: relative;
 }
 
 .LeaderboardItem__content {
   box-sizing: border-box;
-  padding: 15px;
-  float: left;
-  width: 75%;
-
-  @include media-max($breakpoint-xl) {
-    width: 80%;
-  }
-
-  @include media-max($breakpoint-l) {
-    width: 80%;
-  }
-}
-
-.LeaderboardItem__details {
-  width: 50%;
-  float: left;
+  width: 100%;
+  padding: $x-4 $x-16;
 
   .LeaderboardItem__name {
     box-sizing: border-box;
@@ -52,48 +40,27 @@
     font-weight: bold;
     line-height: 1.2;
   }
+}
 
-  .LeaderboardItem__rank {
-    font-size: 12px;
-    color: $ehw-grey;
-  }
+.LeaderboardItem__rank {
+  font-size: $x-4;
+  color: $ehw-grey;
+  position: absolute;
+  top: 50%;
+  right: $x-4;
+  margin-top: -$x-2;
+  font-weight: bold;
 }
 
 .LeaderboardItem__image {
-  box-sizing: border-box;
-  padding: 15px;
-  text-align: center;
-  float: left;
-  border-radius: 50%;
-  width: 25%;
-
-  @include media-max($breakpoint-l) {
-    width: 15%;
-    float: left;
-    padding: 15px;
-  }
-
-  @include media-max($breakpoint-xl) {
-    width: 20%;
-  }
+  position: absolute;
+  left: $x-4;
+  top: 50%;
+  width: $x-8;
+  margin-top: -$x-4;
 
   img {
-    width: 100%;
+    max-width: 100%;
     border-radius: 50%;
-    border: 0;
-  }
-}
-
-.LeaderboardItem__amount {
-  box-sizing: border-box;
-  display: inline-block;
-  width: 50%;
-  font-weight: bold;
-  font-size: 16px;
-  padding: 10px;
-  text-align: right;
-
-  @include media-max($breakpoint-l) {
-    padding: 0;
   }
 }

--- a/src/components/leaderboards/LeaderboardItem/style.scss
+++ b/src/components/leaderboards/LeaderboardItem/style.scss
@@ -61,5 +61,6 @@
   img {
     max-width: 100%;
     border-radius: 50%;
+    border: 0;
   }
 }

--- a/src/components/leaderboards/LeaderboardPaging/__tests__/LeaderboardPaging-test.js
+++ b/src/components/leaderboards/LeaderboardPaging/__tests__/LeaderboardPaging-test.js
@@ -1,90 +1,27 @@
 "use strict";
+
 jest.autoMockOff();
-jest.mock('../../../../api/charities');
 
 describe('LeaderboardPaging', function() {
-  var React              = require('react/addons');
-  var LeaderboardPaging  = require('../');
-  var TestUtils          = React.addons.TestUtils;
-  var findByClass        = TestUtils.findRenderedDOMComponentWithClass;
-  var scryByClass        = TestUtils.scryRenderedDOMComponentsWithClass;
+  var React             = require('react/addons');
+  var LeaderboardPaging = require('../');
+  var TestUtils         = React.addons.TestUtils;
+  var findByClass       = TestUtils.findRenderedDOMComponentWithClass;
 
-  describe('LeaderboardPaging', function() {
+  describe('component defaults', function() {
     var leaderboardPaging;
     var component;
-    var nextButton;
-    var prevButton;
     var callback = jest.genMockFunction();
 
-    describe('paging defaults', function() {
-      beforeEach(function() {
-        leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 1 } pageCount={ 4 } />;
+    beforeEach(function() {
+      leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 1 } pageCount={ 4 } />;
 
-        component  = TestUtils.renderIntoDocument(leaderboardPaging);
-        nextButton = findByClass(component, 'LeaderboardPaging__nextBtn').getDOMNode();
-        prevButton = findByClass(component, 'LeaderboardPaging__prevBtn').getDOMNode();
-      });
-
-      it('renders a component', function() {
-        expect(component).not.toBeNull();
-      });
-
-      it('displays a right pointing caret for on the next button', function() {
-        var nextIcon = findByClass(component, 'fa-caret-right').getDOMNode();
-        expect(nextIcon).not.toBeNull();
-      });
-
-      it('triggers a callback when the next button is clicked', function() {
-        expect(nextButton).not.toBeNull();
-        TestUtils.Simulate.click(nextButton);
-        expect(callback).toBeCalled();
-      });
-
-      it('triggers a callback when the prev button is clicked', function() {
-        expect(prevButton).not.toBeNull();
-        TestUtils.Simulate.click(prevButton);
-        expect(callback).toBeCalled();
-      });
+      component  = TestUtils.renderIntoDocument(leaderboardPaging);
     });
 
-    describe('previous button states', function() {
-      it('has no active modifier class by default', function() {
-        var leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 1 } pageCount={ 4 } />;
-
-        var component  = TestUtils.renderIntoDocument(leaderboardPaging);
-        var prevButton = findByClass(component, 'LeaderboardPaging__prevBtn').getDOMNode();
-
-        expect(prevButton.className).not.toContain('LeaderboardPaging__prevBtn--active');
-      });
-
-      it('has a active modifier class if not on the first page', function() {
-        var leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 2 } pageCount={ 4 } />;
-
-        var component  = TestUtils.renderIntoDocument(leaderboardPaging);
-        var prevButton = findByClass(component, 'LeaderboardPaging__prevBtn').getDOMNode();
-
-        expect(prevButton.className).toContain('LeaderboardPaging__prevBtn--active');
-      });
-    });
-
-    describe('next button states', function() {
-      it('has an active modifier class by default', function() {
-        var leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 1 } pageCount={ 4 } />;
-
-        var component  = TestUtils.renderIntoDocument(leaderboardPaging);
-        var nextButton = findByClass(component, 'LeaderboardPaging__nextBtn').getDOMNode();
-
-        expect(nextButton.className).toContain('LeaderboardPaging__nextBtn--active');
-      });
-
-      it('has the active modifier class removed if on the last page', function() {
-        var leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 4 } pageCount={ 4 } />;
-
-        var component  = TestUtils.renderIntoDocument(leaderboardPaging);
-        var nextButton = findByClass(component, 'LeaderboardPaging__nextBtn').getDOMNode();
-
-        expect(nextButton.className).not.toContain('LeaderboardPaging__nextBtn--active');
-      });
+    it('renders a component', function() {
+      expect(component).not.toBeNull();
+      expect(component.getDOMNode().className).toContain('LeaderboardPaging');
     });
   });
 });

--- a/src/components/leaderboards/LeaderboardPaging/__tests__/LeaderboardPaging-test.js
+++ b/src/components/leaderboards/LeaderboardPaging/__tests__/LeaderboardPaging-test.js
@@ -1,0 +1,90 @@
+"use strict";
+jest.autoMockOff();
+jest.mock('../../../../api/charities');
+
+describe('LeaderboardPaging', function() {
+  var React              = require('react/addons');
+  var LeaderboardPaging  = require('../');
+  var TestUtils          = React.addons.TestUtils;
+  var findByClass        = TestUtils.findRenderedDOMComponentWithClass;
+  var scryByClass        = TestUtils.scryRenderedDOMComponentsWithClass;
+
+  describe('LeaderboardPaging', function() {
+    var leaderboardPaging;
+    var component;
+    var nextButton;
+    var prevButton;
+    var callback = jest.genMockFunction();
+
+    describe('paging defaults', function() {
+      beforeEach(function() {
+        leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 1 } pageCount={ 4 } />;
+
+        component  = TestUtils.renderIntoDocument(leaderboardPaging);
+        nextButton = findByClass(component, 'LeaderboardPaging__nextBtn').getDOMNode();
+        prevButton = findByClass(component, 'LeaderboardPaging__prevBtn').getDOMNode();
+      });
+
+      it('renders a component', function() {
+        expect(component).not.toBeNull();
+      });
+
+      it('displays a right pointing caret for on the next button', function() {
+        var nextIcon = findByClass(component, 'fa-caret-right').getDOMNode();
+        expect(nextIcon).not.toBeNull();
+      });
+
+      it('triggers a callback when the next button is clicked', function() {
+        expect(nextButton).not.toBeNull();
+        TestUtils.Simulate.click(nextButton);
+        expect(callback).toBeCalled();
+      });
+
+      it('triggers a callback when the prev button is clicked', function() {
+        expect(prevButton).not.toBeNull();
+        TestUtils.Simulate.click(prevButton);
+        expect(callback).toBeCalled();
+      });
+    });
+
+    describe('previous button states', function() {
+      it('has no active modifier class by default', function() {
+        var leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 1 } pageCount={ 4 } />;
+
+        var component  = TestUtils.renderIntoDocument(leaderboardPaging);
+        var prevButton = findByClass(component, 'LeaderboardPaging__prevBtn').getDOMNode();
+
+        expect(prevButton.className).not.toContain('LeaderboardPaging__prevBtn--active');
+      });
+
+      it('has a active modifier class if not on the first page', function() {
+        var leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 2 } pageCount={ 4 } />;
+
+        var component  = TestUtils.renderIntoDocument(leaderboardPaging);
+        var prevButton = findByClass(component, 'LeaderboardPaging__prevBtn').getDOMNode();
+
+        expect(prevButton.className).toContain('LeaderboardPaging__prevBtn--active');
+      });
+    });
+
+    describe('next button states', function() {
+      it('has an active modifier class by default', function() {
+        var leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 1 } pageCount={ 4 } />;
+
+        var component  = TestUtils.renderIntoDocument(leaderboardPaging);
+        var nextButton = findByClass(component, 'LeaderboardPaging__nextBtn').getDOMNode();
+
+        expect(nextButton.className).toContain('LeaderboardPaging__nextBtn--active');
+      });
+
+      it('has the active modifier class removed if on the last page', function() {
+        var leaderboardPaging = <LeaderboardPaging nextPage={ callback } prevPage={ callback } currentPage={ 4 } pageCount={ 4 } />;
+
+        var component  = TestUtils.renderIntoDocument(leaderboardPaging);
+        var nextButton = findByClass(component, 'LeaderboardPaging__nextBtn').getDOMNode();
+
+        expect(nextButton.className).not.toContain('LeaderboardPaging__nextBtn--active');
+      });
+    });
+  });
+});

--- a/src/components/leaderboards/LeaderboardPaging/index.js
+++ b/src/components/leaderboards/LeaderboardPaging/index.js
@@ -8,14 +8,6 @@ var cx    = require('react/lib/cx');
 module.exports = React.createClass({
   displayName: 'LeaderboardPaging',
 
-  handleNext: function() {
-    this.props.nextPage();
-  },
-
-  handlePrev: function() {
-    this.props.prevPage();
-  },
-
   renderPrevBtn: function() {
     var classes = cx({
       "LeaderboardPaging__prevBtn": true,
@@ -23,7 +15,7 @@ module.exports = React.createClass({
     });
 
     return (
-      <div onClick={ this.handlePrev } className={ classes }>
+      <div onClick={ this.props.prevPage } className={ classes }>
         <Icon className="LeaderboardPaging__icon" icon="caret-left"/>
       </div>
     );
@@ -39,7 +31,7 @@ module.exports = React.createClass({
     });
 
     return (
-      <div onClick={ this.handleNext } className={ classes }>
+      <div onClick={ this.props.nextPage } className={ classes }>
         <Icon className="LeaderboardPaging__icon" icon="caret-right"/>
       </div>
     );

--- a/src/components/leaderboards/LeaderboardPaging/index.js
+++ b/src/components/leaderboards/LeaderboardPaging/index.js
@@ -1,47 +1,21 @@
 "use strict";
 
-var _     = require('lodash');
-var React = require('react');
-var Icon  = require('../../helpers/Icon');
-var cx    = require('react/lib/cx');
+var React                   = require('react');
+var LeaderboardPagingButton = require('../LeaderboardPagingButton');
 
 module.exports = React.createClass({
   displayName: 'LeaderboardPaging',
 
-  renderPrevBtn: function() {
-    var classes = cx({
-      "LeaderboardPaging__prevBtn": true,
-      "LeaderboardPaging__prevBtn--active": this.props.currentPage > 1
-    });
-
-    return (
-      <div onClick={ this.props.prevPage } className={ classes }>
-        <Icon className="LeaderboardPaging__icon" icon="caret-left"/>
-      </div>
-    );
-  },
-
-  renderNextBtn: function() {
-    var pageCount = this.props.pageCount;
-    var currentPage = this.props.currentPage;
-
-    var classes = cx({
-      "LeaderboardPaging__nextBtn": true,
-      "LeaderboardPaging__nextBtn--active": currentPage < pageCount
-    });
-
-    return (
-      <div onClick={ this.props.nextPage } className={ classes }>
-        <Icon className="LeaderboardPaging__icon" icon="caret-right"/>
-      </div>
-    );
-  },
-
   render: function() {
+    var props = {
+      pageCount: this.props.pageCount,
+      currentPage: this.props.currentPage
+    };
+
     return (
       <div className="LeaderboardPaging">
-        { this.renderPrevBtn() }
-        { this.renderNextBtn() }
+        <LeaderboardPagingButton type="prev" action={ this.props.prevPage } { ...props } />
+        <LeaderboardPagingButton type="next" action={ this.props.nextPage } { ...props } />
       </div>
     );
   }

--- a/src/components/leaderboards/LeaderboardPaging/index.js
+++ b/src/components/leaderboards/LeaderboardPaging/index.js
@@ -1,0 +1,56 @@
+"use strict";
+
+var _     = require('lodash');
+var React = require('react');
+var Icon  = require('../../helpers/Icon');
+var cx    = require('react/lib/cx');
+
+module.exports = React.createClass({
+  displayName: 'LeaderboardPaging',
+
+  handleNext: function() {
+    this.props.nextPage();
+  },
+
+  handlePrev: function() {
+    this.props.prevPage();
+  },
+
+  renderPrevBtn: function() {
+    var classes = cx({
+      "LeaderboardPaging__prevBtn": true,
+      "LeaderboardPaging__prevBtn--active": this.props.currentPage > 1
+    });
+
+    return (
+      <div onClick={ this.handlePrev } className={ classes }>
+        <Icon className="LeaderboardPaging__icon" icon="caret-left"/>
+      </div>
+    );
+  },
+
+  renderNextBtn: function() {
+    var pageCount = this.props.pageCount;
+    var currentPage = this.props.currentPage;
+
+    var classes = cx({
+      "LeaderboardPaging__nextBtn": true,
+      "LeaderboardPaging__nextBtn--active": currentPage < pageCount
+    });
+
+    return (
+      <div onClick={ this.handleNext } className={ classes }>
+        <Icon className="LeaderboardPaging__icon" icon="caret-right"/>
+      </div>
+    );
+  },
+
+  render: function() {
+    return (
+      <div className="LeaderboardPaging">
+        { this.renderPrevBtn() }
+        { this.renderNextBtn() }
+      </div>
+    );
+  }
+});

--- a/src/components/leaderboards/LeaderboardPaging/style.scss
+++ b/src/components/leaderboards/LeaderboardPaging/style.scss
@@ -3,39 +3,3 @@
   text-align: center;
   margin: $x-4;
 }
-
-.LeaderboardPaging__prevBtn,
-.LeaderboardPaging__nextBtn {
-  display: inline-block;
-  border: 1px solid #fff;
-  margin: $x-1;
-  cursor: pointer;
-  font-size: $x-6;
-  line-height: 1;
-  border-radius: $ehw-border-radius;
-  transition: opacity 0.25s ease-in-out;
-
-  &,
-  &:hover,
-  &:focus {
-    opacity: 0.1;
-  }
-}
-
-.LeaderboardPaging__prevBtn {
-  padding: 0 10px 0 8px;
-}
-
-.LeaderboardPaging__nextBtn {
-  padding: 0 8px 0 10px;
-}
-
-.LeaderboardPaging__prevBtn--active,
-.LeaderboardPaging__nextBtn--active {
-  opacity: 0.66;
-
-  &:hover,
-  &:focus {
-    opacity: 1;
-  }
-}

--- a/src/components/leaderboards/LeaderboardPaging/style.scss
+++ b/src/components/leaderboards/LeaderboardPaging/style.scss
@@ -1,0 +1,30 @@
+.LeaderboardPaging {
+  clear: both;
+  text-align: center;
+  margin: $x-4;
+}
+
+.LeaderboardPaging__prevBtn,
+.LeaderboardPaging__nextBtn {
+  display: inline-block;
+  border: 1px solid #fff;
+  margin: $x-1;
+  cursor: pointer;
+  font-size: $x-6;
+  line-height: 1;
+  opacity: 0.5;
+  border-radius: $ehw-border-radius;
+}
+
+.LeaderboardPaging__prevBtn {
+  padding: 0 10px 0 8px;
+}
+
+.LeaderboardPaging__nextBtn {
+  padding: 0 8px 0 10px;
+}
+
+.LeaderboardPaging__prevBtn--active,
+.LeaderboardPaging__nextBtn--active {
+  opacity: 1;
+}

--- a/src/components/leaderboards/LeaderboardPaging/style.scss
+++ b/src/components/leaderboards/LeaderboardPaging/style.scss
@@ -12,8 +12,14 @@
   cursor: pointer;
   font-size: $x-6;
   line-height: 1;
-  opacity: 0.5;
   border-radius: $ehw-border-radius;
+  transition: opacity 0.25s ease-in-out;
+
+  &,
+  &:hover,
+  &:focus {
+    opacity: 0.1;
+  }
 }
 
 .LeaderboardPaging__prevBtn {
@@ -26,5 +32,10 @@
 
 .LeaderboardPaging__prevBtn--active,
 .LeaderboardPaging__nextBtn--active {
-  opacity: 1;
+  opacity: 0.66;
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+  }
 }

--- a/src/components/leaderboards/LeaderboardPagingButton/__tests__/LeaderboardPagingButton-test.js
+++ b/src/components/leaderboards/LeaderboardPagingButton/__tests__/LeaderboardPagingButton-test.js
@@ -1,0 +1,84 @@
+"use strict";
+
+jest.autoMockOff();
+
+var React                   = require('react/addons');
+var LeaderboardPagingButton = require('../');
+var TestUtils               = React.addons.TestUtils;
+var findByClass             = TestUtils.findRenderedDOMComponentWithClass;
+
+describe('LeaderboardPagingButton', function() {
+  var leaderboardPagingButton;
+  var component;
+  var callback = jest.genMockFunction();
+
+  var prevActiveClass = 'LeaderboardPagingButton__prev--active';
+  var nextActiveClass = 'LeaderboardPagingButton__next--active';
+
+  describe('paging defaults', function() {
+    beforeEach(function() {
+      leaderboardPagingButton = <LeaderboardPagingButton type="next" action={ callback } currentPage={ 1 } pageCount={ 4 } />;
+
+      component  = TestUtils.renderIntoDocument(leaderboardPagingButton);
+    });
+
+    it('renders a component', function() {
+      expect(component).not.toBeNull();
+    });
+
+    it('triggers a callback when the button is clicked', function() {
+      var pagingButton = findByClass(component, 'LeaderboardPagingButton__next');
+
+      TestUtils.Simulate.click(pagingButton);
+      expect(callback).toBeCalled();
+    });
+  });
+
+  describe('next button', function() {
+    it('displays a right pointing caret icon', function() {
+      leaderboardPagingButton = <LeaderboardPagingButton type="next" action={ callback } currentPage={ 1 } pageCount={ 4 } />;
+      component = TestUtils.renderIntoDocument(leaderboardPagingButton);
+
+      var nextIcon = findByClass(component, 'fa-caret-right').getDOMNode();
+      expect(nextIcon).not.toBeNull();
+    });
+
+    it('has an active modifier class by default', function() {
+      leaderboardPagingButton = <LeaderboardPagingButton type="next" action={ callback } currentPage={ 1 } pageCount={ 4 } />;
+
+      component = TestUtils.renderIntoDocument(leaderboardPagingButton);
+      expect(component.getDOMNode().className).toContain(nextActiveClass);
+    });
+
+    it('has no active modifier class if the last page is displayed', function() {
+      leaderboardPagingButton = <LeaderboardPagingButton type="next" action={ callback } currentPage={ 4 } pageCount={ 4 } />;
+
+      component = TestUtils.renderIntoDocument(leaderboardPagingButton);
+      expect(component.getDOMNode().className).not.toContain(nextActiveClass);
+    });
+  });
+
+  describe('previous button', function() {
+    it('displays a left pointing caret icon', function() {
+      leaderboardPagingButton = <LeaderboardPagingButton type="prev" action={ callback } currentPage={ 4 } pageCount={ 4 } />;
+      component = TestUtils.renderIntoDocument(leaderboardPagingButton);
+
+      var prevIcon = findByClass(component, 'fa-caret-left').getDOMNode();
+      expect(prevIcon).not.toBeNull();
+    });
+
+    it('has no active modifier class by default', function() {
+      leaderboardPagingButton = <LeaderboardPagingButton type="prev" action={ callback } currentPage={ 1 } pageCount={ 4 } />;
+
+      component = TestUtils.renderIntoDocument(leaderboardPagingButton);
+      expect(component.getDOMNode().className).not.toContain(prevActiveClass);
+    });
+
+    it('has an active modifier class if the last page is displayed', function() {
+      leaderboardPagingButton = <LeaderboardPagingButton type="prev" action={ callback } currentPage={ 4 } pageCount={ 4 } />;
+
+      component = TestUtils.renderIntoDocument(leaderboardPagingButton);
+      expect(component.getDOMNode().className).toContain(prevActiveClass);
+    });
+  });
+});

--- a/src/components/leaderboards/LeaderboardPagingButton/index.js
+++ b/src/components/leaderboards/LeaderboardPagingButton/index.js
@@ -1,0 +1,42 @@
+"use strict";
+
+var React = require('react');
+var Icon  = require('../../helpers/Icon');
+var cx    = require('react/lib/cx');
+
+module.exports = React.createClass({
+  displayName: 'LeaderboardPagingButton',
+
+  handleClick: function() {
+    this.props.action();
+  },
+
+  render: function() {
+    var pageCount   = this.props.pageCount;
+    var currentPage = this.props.currentPage;
+    var classes;
+    var iconName;
+
+    if (this.props.type == "next") {
+      classes = cx({
+        "LeaderboardPagingButton__next": true,
+        "LeaderboardPagingButton__next--active": currentPage < pageCount
+      });
+
+      iconName = "caret-right";
+    } else {
+      classes = cx({
+        "LeaderboardPagingButton__prev": true,
+        "LeaderboardPagingButton__prev--active": currentPage > 1
+      });
+
+      iconName = "caret-left";
+    }
+
+    return (
+      <div onClick={ this.handleClick } className={ classes }>
+        <Icon className="LeaderboardPagingButton__icon" icon={ iconName } />
+      </div>
+    );
+  },
+});

--- a/src/components/leaderboards/LeaderboardPagingButton/style.scss
+++ b/src/components/leaderboards/LeaderboardPagingButton/style.scss
@@ -1,0 +1,35 @@
+.LeaderboardPagingButton__prev,
+.LeaderboardPagingButton__next {
+  display: inline-block;
+  border: 1px solid #fff;
+  margin: $x-1;
+  cursor: pointer;
+  font-size: $x-6;
+  line-height: 1;
+  border-radius: $ehw-border-radius;
+  transition: opacity 0.25s ease-in-out;
+
+  &,
+  &:hover,
+  &:focus {
+    opacity: 0.1;
+  }
+}
+
+.LeaderboardPagingButton__prev {
+  padding: 0 10px 0 8px;
+}
+
+.LeaderboardPagingButton__next {
+  padding: 0 8px 0 10px;
+}
+
+.LeaderboardPagingButton__prev--active,
+.LeaderboardPagingButton__next--active {
+  opacity: 0.66;
+
+  &:hover,
+  &:focus {
+    opacity: 1;
+  }
+}

--- a/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
+++ b/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
@@ -8,9 +8,9 @@ describe('TeamLeaderboard', function() {
   var TeamLeaderboard     = require('../');
   var LeaderboardItem     = require('../../LeaderboardItem/');
   var TeamLeaderboardItem = require('../../TeamLeaderboardItem/');
+  var LeaderboardPaging   = require('../../LeaderboardPaging/');
   var TestUtils           = React.addons.TestUtils;
   var findByClass         = TestUtils.findRenderedDOMComponentWithClass;
-  var scryByClass         = TestUtils.scryRenderedDOMComponentsWithClass;
 
   describe('Component defaults', function() {
     var teamLeaderboard;
@@ -126,6 +126,28 @@ describe('TeamLeaderboard', function() {
       var element = TestUtils.renderIntoDocument(leaderboard);
       var template = TestUtils.scryRenderedComponentsWithType(element, TeamLeaderboardItem);
       expect(element.props.altTemplate).toBeTruthy();
+    });
+  });
+
+  describe('paging button rendering', function() {
+    it('renders a paging component if multiple pages are available', function() {
+      var leaderboard = <TeamLeaderboard campaignUid="au-0" limit={ 10 } pageSize={ 5 } />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+      element.setState({ isLoading: false });
+
+      var paging = <LeaderboardPaging />;
+      var pagingFunction = element.renderPaging();
+      expect(pagingFunction).toBeDefined();
+    });
+
+    it('does not render a paging component if only 1 page is available', function() {
+      var leaderboard = <TeamLeaderboard campaignUid="au-0" limit={ 5 } pageSize={ 5 } />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+      element.setState({ isLoading: false });
+
+      var paging = <LeaderboardPaging />;
+      var pagingFunction = element.renderPaging();
+      expect(pagingFunction).toBeUndefined();
     });
   });
 });

--- a/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
+++ b/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
@@ -1,11 +1,12 @@
 "use strict";
+
 jest.autoMockOff();
-jest.mock('../../../../api/campaigns');
 
 describe('TeamLeaderboard', function() {
   var _                   = require('lodash');
   var React               = require('react/addons');
   var TeamLeaderboard     = require('../');
+  var LeaderboardItem     = require('../../LeaderboardItem/');
   var TeamLeaderboardItem = require('../../TeamLeaderboardItem/');
   var TestUtils           = React.addons.TestUtils;
   var findByClass         = TestUtils.findRenderedDOMComponentWithClass;
@@ -114,11 +115,17 @@ describe('TeamLeaderboard', function() {
 
   describe('rendering different templates', function(){
     it('renders LeaderboardItem component for children by default', function() {
-      // todo
+      var leaderboard = <TeamLeaderboard campaignUid="au-0" />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+      var template = TestUtils.scryRenderedComponentsWithType(element, LeaderboardItem);
+      expect(element.props.altTemplate).toBeFalsy();
     });
 
     it('renders TeamLeaderboardItem component for children when set', function() {
-      // todo
+      var leaderboard = <TeamLeaderboard campaignUid="au-0" altTemplate={ true } />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+      var template = TestUtils.scryRenderedComponentsWithType(element, TeamLeaderboardItem);
+      expect(element.props.altTemplate).toBeTruthy();
     });
   });
 });

--- a/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
+++ b/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
@@ -44,7 +44,7 @@ describe('TeamLeaderboard', function() {
     };
 
     beforeEach(function() {
-      leaderboard = <TeamLeaderboard campaignUid="au-0" i18n={ translation } type="team" />;
+      leaderboard = <TeamLeaderboard campaignUid="au-0" i18n={ translation } />;
       element = TestUtils.renderIntoDocument(leaderboard);
     });
 

--- a/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
+++ b/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
@@ -1,0 +1,114 @@
+"use strict";
+jest.autoMockOff();
+jest.mock('../../../../api/campaigns');
+
+describe('TeamLeaderboard', function() {
+  var _                   = require('lodash');
+  var React               = require('react/addons');
+  var TeamLeaderboard     = require('../');
+  var TeamLeaderboardItem = require('../../TeamLeaderboardItem/');
+  var TestUtils           = React.addons.TestUtils;
+  var findByClass         = TestUtils.findRenderedDOMComponentWithClass;
+  var scryByClass         = TestUtils.scryRenderedDOMComponentsWithClass;
+
+  describe('Component defaults', function() {
+    var teamLeaderboard;
+    var element;
+
+    beforeEach(function() {
+      teamLeaderboard = <TeamLeaderboard campaignUid="au-0" />;
+      element = TestUtils.renderIntoDocument(teamLeaderboard);
+    });
+
+    it('renders something', function() {
+      expect(element).not.toBeNull();
+    });
+
+    it('renders a default heading', function() {
+      var heading = findByClass(element, 'TeamLeaderboard__heading');
+      expect(heading.getDOMNode().textContent).toBe('Top Teams');
+    });
+
+    it('renders a loading icon', function() {
+      element.setState({ isLoading: true });
+      findByClass(element, 'TeamLeaderboard__loading');
+    });
+  });
+
+  describe('Custom component props', function() {
+    var leaderboard;
+    var element;
+    var translation = {
+      heading: 'Top Teams'
+    };
+
+    beforeEach(function() {
+      leaderboard = <TeamLeaderboard campaignUid="au-0" i18n={ translation } type="team" />;
+      element = TestUtils.renderIntoDocument(leaderboard);
+    });
+
+    it('renders a custom heading', function() {
+      var heading = findByClass(element, 'TeamLeaderboard__heading');
+      expect(heading.getDOMNode().textContent).toBe(translation.heading);
+    });
+  });
+
+  describe('standard competition ranking system', function() {
+    var element;
+    var data;
+
+    beforeEach(function() {
+      element = TestUtils.renderIntoDocument(<TeamLeaderboard campaignUid="au-0" />);
+    });
+
+    it('assigns rank in order of amount', function(){
+      data = [
+        { id: 1, amount: 1100 },
+        { id: 2, amount: 1000 },
+        { id: 3, amount: 900 }
+      ];
+
+      element.rankLeaderboard(data);
+      expect(_.pluck(data, 'rank')).toEqual([1, 2, 3]);
+    });
+
+    it('gives results with the same amount the same rank', function() {
+      data = [
+        { id: 1, amount: 1000 },
+        { id: 2, amount: 1000 }
+      ];
+
+      element.rankLeaderboard(data);
+      expect(_.pluck(data, 'rank')).toEqual([1, 1]);
+    });
+
+    it('leaves a gap to compensate for items with the same rank', function(){
+      data = [
+        { id: 1, amount: 1100 },
+        { id: 2, amount: 1000 },
+        { id: 3, amount: 1000 },
+        { id: 4, amount: 1000 },
+        { id: 5, amount: 900 }
+      ];
+
+      element.rankLeaderboard(data);
+      expect(_.pluck(data, 'rank')).toEqual([1, 2, 2, 2, 5]);
+    });
+  });
+
+  describe('Number formatting options', function() {
+    it('renders in a abbreviated format by default', function() {
+      var leaderboard = <TeamLeaderboard campaignUid="au-0" />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+
+      expect(element.formatAmount(100000)).toEqual('$1 k');
+    });
+
+    it('renders a different format if given acceptable numeral.js string', function() {
+      var leaderboard = <TeamLeaderboard campaignUid="au-0" currencyFormat="0.00" />;
+      var element = TestUtils.renderIntoDocument(leaderboard);
+
+      expect(element.formatAmount(100000)).toEqual('$1000.00');
+    });
+  });
+});

--- a/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
+++ b/src/components/leaderboards/TeamLeaderboard/__tests__/TeamLeaderboard-test.js
@@ -111,4 +111,14 @@ describe('TeamLeaderboard', function() {
       expect(element.formatAmount(100000)).toEqual('$1000.00');
     });
   });
+
+  describe('rendering different templates', function(){
+    it('renders LeaderboardItem component for children by default', function() {
+      // todo
+    });
+
+    it('renders TeamLeaderboardItem component for children when set', function() {
+      // todo
+    });
+  });
 });

--- a/src/components/leaderboards/TeamLeaderboard/index.js
+++ b/src/components/leaderboards/TeamLeaderboard/index.js
@@ -1,15 +1,16 @@
 "use strict";
 
-var _                   = require('lodash');
-var React               = require('react');
-var I18nMixin           = require('../../mixins/I18n');
-var DOMInfoMixin        = require('../../mixins/DOMInfo');
-var LeaderboardMixin    = require('../../mixins/Leaderboard');
-var Icon                = require('../../helpers/Icon');
-var TeamLeaderboardItem = require('../TeamLeaderboardItem');
-var numeral             = require('numeral');
-var addEventListener    = require('../../../lib/addEventListener');
-var removeEventListener = require('../../../lib/removeEventListener');
+var _                       = require('lodash');
+var React                   = require('react/addons');
+var I18nMixin               = require('../../mixins/I18n');
+var DOMInfoMixin            = require('../../mixins/DOMInfo');
+var LeaderboardMixin        = require('../../mixins/Leaderboard');
+var Icon                    = require('../../helpers/Icon');
+var TeamLeaderboardItem     = require('../TeamLeaderboardItem');
+var numeral                 = require('numeral');
+var addEventListener        = require('../../../lib/addEventListener');
+var removeEventListener     = require('../../../lib/removeEventListener');
+var ReactCSSTransitionGroup = React.addons.CSSTransitionGroup;
 
 module.exports = React.createClass({
   mixins: [I18nMixin, DOMInfoMixin, LeaderboardMixin],
@@ -57,26 +58,26 @@ module.exports = React.createClass({
   },
 
   componentDidMount: function() {
-    addEventListener(window, 'resize', this.setchildWidth);
+    addEventListener(window, 'resize', this.setChildWidth);
   },
 
   componentWillUnmount: function() {
-    removeEventListener(window, 'resize', this.setchildWidth);
+    removeEventListener(window, 'resize', this.setChildWidth);
   },
 
-  setchildWidth: _.debounce(function() {
+  setChildWidth: _.debounce(function() {
     this.setState({
       childWidth: this.getChildrenWidth(this.props.childWidth, this.props.pageSize)
     });
   }, 100),
 
   renderLeaderboardItems: function() {
-    if (this.state.isLoading) {
-      return <Icon className="Leaderboard__loading" icon="refresh" />;
-    }
-
     var currentPage = this.state.currentPage - 1;
     var board = this.state.boardData[currentPage];
+
+    if (this.state.isLoading) {
+      return <Icon className="TeamLeaderboard__loading" icon="refresh" />;
+    }
 
     if (!board) {
       return;
@@ -111,10 +112,12 @@ module.exports = React.createClass({
     };
 
     return (
-      <div className="Leaderboard" style={ customStyle }>
-        <h3 className="Leaderboard__heading">{ heading }</h3>
-        <ol className="Leaderboard__items">
-          { this.renderLeaderboardItems() }
+      <div className="TeamLeaderboard" style={ customStyle }>
+        <h3 className="TeamLeaderboard__heading">{ heading }</h3>
+        <ol className="TeamLeaderboard__items">
+          <ReactCSSTransitionGroup transitionName="TeamLeaderboard__animation" component="div">
+            { this.renderLeaderboardItems() }
+          </ReactCSSTransitionGroup>
         </ol>
         { this.renderPaging() }
       </div>

--- a/src/components/leaderboards/TeamLeaderboard/index.js
+++ b/src/components/leaderboards/TeamLeaderboard/index.js
@@ -6,21 +6,21 @@ var I18nMixin           = require('../../mixins/I18n');
 var DOMInfoMixin        = require('../../mixins/DOMInfo');
 var LeaderboardMixin    = require('../../mixins/Leaderboard');
 var Icon                = require('../../helpers/Icon');
-var LeaderboardItem     = require('../LeaderboardItem');
+var TeamLeaderboardItem = require('../TeamLeaderboardItem');
 var numeral             = require('numeral');
 var addEventListener    = require('../../../lib/addEventListener');
 var removeEventListener = require('../../../lib/removeEventListener');
 
 module.exports = React.createClass({
   mixins: [I18nMixin, DOMInfoMixin, LeaderboardMixin],
-  displayName: "Leaderboard",
+  displayName: "TeamLeaderboard",
   propTypes: {
     campaignSlug: React.PropTypes.string,
     campaignUid: React.PropTypes.string,
     charitySlug: React.PropTypes.string,
     charityUid: React.PropTypes.string,
     country: React.PropTypes.oneOf(['au', 'nz', 'uk', 'us']),
-    type: React.PropTypes.oneOf(['team', 'individual']),
+    type: React.PropTypes.oneOf(['team']),
     limit: React.PropTypes.number,
     pageSize: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
@@ -31,18 +31,18 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
-      type: 'individual',
-      limit: 48,
-      pageSize: 12,
+      type: 'team',
+      limit: 24,
+      pageSize: 4,
       backgroundColor: null,
       textColor: null,
-      childWidth: 250,
-      currencyFormat: '0,0[.]00',
+      childWidth: 240,
+      currencyFormat: '0[.]00 a',
       defaultI18n: {
         raisedTitle: 'Raised',
         membersTitle: 'Members',
         symbol: '$',
-        heading: 'Top Individuals'
+        heading: 'Top Teams'
       }
     };
   },
@@ -52,21 +52,21 @@ module.exports = React.createClass({
       isLoading: false,
       boardData: [],
       currentPage: 1,
-      itemWidth: this.props.childWidth,
+      childWidth: '',
     };
   },
 
   componentDidMount: function() {
-    addEventListener(window, 'resize', this.setItemWidth);
+    addEventListener(window, 'resize', this.setchildWidth);
   },
 
   componentWillUnmount: function() {
-    removeEventListener(window, 'resize', this.setItemWidth);
+    removeEventListener(window, 'resize', this.setchildWidth);
   },
 
-  setItemWidth: _.debounce(function() {
+  setchildWidth: _.debounce(function() {
     this.setState({
-      itemWidth: this.getChildrenWidth(this.props.childWidth, this.props.pageSize)
+      childWidth: this.getChildrenWidth(this.props.childWidth, this.props.pageSize)
     });
   }, 100),
 
@@ -87,15 +87,17 @@ module.exports = React.createClass({
       var formattedRank = numeral(d.rank).format('0o');
 
       return (
-        <LeaderboardItem
+        <TeamLeaderboardItem
           key={ d.id }
-          rank={ formattedRank }
           name={ d.name }
           url={ d.url }
           isoCode={ d.isoCode }
           amount={ formattedAmount }
-          imgSrc={ d.medImgSrc }
-          width={ this.state.itemWidth } />
+          totalMembers={ d.totalMembers }
+          imgSrc={ d.imgSrc }
+          raisedTitle={ this.t('raisedTitle') }
+          membersTitle={ this.t('membersTitle') }
+          width={ this.state.childWidth } />
       );
 
     }, this);

--- a/src/components/leaderboards/TeamLeaderboard/index.js
+++ b/src/components/leaderboards/TeamLeaderboard/index.js
@@ -22,7 +22,6 @@ module.exports = React.createClass({
     charitySlug: React.PropTypes.string,
     charityUid: React.PropTypes.string,
     country: React.PropTypes.oneOf(['au', 'nz', 'uk', 'us']),
-    type: React.PropTypes.oneOf(['team']),
     limit: React.PropTypes.number,
     pageSize: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
@@ -34,7 +33,6 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
-      type: 'team',
       limit: 48,
       pageSize: 12,
       backgroundColor: null,
@@ -58,6 +56,10 @@ module.exports = React.createClass({
       currentPage: 1,
       childWidth: '',
     };
+  },
+
+  componentWillMount: function() {
+    this.loadLeaderboard('team');
   },
 
   componentDidMount: function() {

--- a/src/components/leaderboards/TeamLeaderboard/index.js
+++ b/src/components/leaderboards/TeamLeaderboard/index.js
@@ -62,6 +62,7 @@ module.exports = React.createClass({
 
   componentDidMount: function() {
     addEventListener(window, 'resize', this.setChildWidth);
+    this.setChildWidth();
   },
 
   componentWillUnmount: function() {
@@ -72,7 +73,7 @@ module.exports = React.createClass({
     this.setState({
       childWidth: this.getChildrenWidth(this.props.childWidth, this.props.pageSize)
     });
-  }, 100),
+  }, 100, { trailing: true }),
 
   renderLeaderboardItems: function() {
     var currentPage = this.state.currentPage - 1;
@@ -90,32 +91,23 @@ module.exports = React.createClass({
       var formattedAmount = this.formatAmount(d.amount);
       var formattedRank = numeral(d.rank).format('0o');
 
-      if (this.props.altTemplate) {
-        return (
-          <TeamLeaderboardItem
-            key={ d.id }
-            name={ d.name }
-            url={ d.url }
-            isoCode={ d.isoCode }
-            amount={ formattedAmount }
-            totalMembers={ d.totalMembers }
-            imgSrc={ d.imgSrc }
-            raisedTitle={ this.t('raisedTitle') }
-            membersTitle={ this.t('membersTitle') }
-            width={ this.state.childWidth } />
-        );
-      }
+      var El = this.props.altTemplate ? TeamLeaderboardItem : LeaderboardItem;
+      var props = {
+        key: d.id,
+        name: d.name,
+        rank: formattedRank,
+        url: d.url,
+        isoCode: d.isoCode,
+        amount: formattedAmount,
+        totalMembers: d.totalMembers,
+        imgSrc: d.imgSrc,
+        raisedTitle: this.t('raisedTitle'),
+        membersTitle: this.t('membersTitle'),
+        width: this.state.childWidth
+      };
 
       return (
-        <LeaderboardItem
-          key={ d.id }
-          rank={ formattedRank }
-          name={ d.name }
-          url={ d.url }
-          isoCode={ d.isoCode }
-          amount={ formattedAmount }
-          imgSrc={ d.medImgSrc }
-          width={ this.state.childWidth } />
+        <El { ...props } />
       );
 
     }, this);

--- a/src/components/leaderboards/TeamLeaderboard/index.js
+++ b/src/components/leaderboards/TeamLeaderboard/index.js
@@ -27,6 +27,7 @@ module.exports = React.createClass({
     pageSize: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
+    childWidth: React.PropTypes.number,
     currencyFormat: React.PropTypes.string,
     i18n: React.PropTypes.object
   },

--- a/src/components/leaderboards/TeamLeaderboard/index.js
+++ b/src/components/leaderboards/TeamLeaderboard/index.js
@@ -6,6 +6,7 @@ var I18nMixin               = require('../../mixins/I18n');
 var DOMInfoMixin            = require('../../mixins/DOMInfo');
 var LeaderboardMixin        = require('../../mixins/Leaderboard');
 var Icon                    = require('../../helpers/Icon');
+var LeaderboardItem         = require('../LeaderboardItem');
 var TeamLeaderboardItem     = require('../TeamLeaderboardItem');
 var numeral                 = require('numeral');
 var addEventListener        = require('../../../lib/addEventListener');
@@ -33,11 +34,12 @@ module.exports = React.createClass({
   getDefaultProps: function() {
     return {
       type: 'team',
-      limit: 24,
-      pageSize: 4,
+      limit: 48,
+      pageSize: 12,
       backgroundColor: null,
       textColor: null,
-      childWidth: 240,
+      childWidth: 250,
+      altTemplate: false,
       currencyFormat: '0[.]00 a',
       defaultI18n: {
         raisedTitle: 'Raised',
@@ -87,17 +89,31 @@ module.exports = React.createClass({
       var formattedAmount = this.formatAmount(d.amount);
       var formattedRank = numeral(d.rank).format('0o');
 
+      if (this.props.altTemplate) {
+        return (
+          <TeamLeaderboardItem
+            key={ d.id }
+            name={ d.name }
+            url={ d.url }
+            isoCode={ d.isoCode }
+            amount={ formattedAmount }
+            totalMembers={ d.totalMembers }
+            imgSrc={ d.imgSrc }
+            raisedTitle={ this.t('raisedTitle') }
+            membersTitle={ this.t('membersTitle') }
+            width={ this.state.childWidth } />
+        );
+      }
+
       return (
-        <TeamLeaderboardItem
+        <LeaderboardItem
           key={ d.id }
+          rank={ formattedRank }
           name={ d.name }
           url={ d.url }
           isoCode={ d.isoCode }
           amount={ formattedAmount }
-          totalMembers={ d.totalMembers }
-          imgSrc={ d.imgSrc }
-          raisedTitle={ this.t('raisedTitle') }
-          membersTitle={ this.t('membersTitle') }
+          imgSrc={ d.medImgSrc }
           width={ this.state.childWidth } />
       );
 

--- a/src/components/leaderboards/TeamLeaderboard/style.scss
+++ b/src/components/leaderboards/TeamLeaderboard/style.scss
@@ -1,23 +1,23 @@
-.Leaderboard {
+.TeamLeaderboard {
   @extend %clearfix;
   background: $ehw-grey-dark;
   font-family: $ehw-sans-serif-fonts;
   font-size: $ehw-default-font-size;
   color: #fff;
 
-  .Leaderboard__heading {
+  .TeamLeaderboard__heading {
     @extend %ehw-tile-heading;
     text-align: center;
   }
 
-  .Leaderboard__items {
+  .TeamLeaderboard__items {
     @extend %clearfix;
     list-style-type: none;
     padding: 0;
     margin: 0;
   }
 
-  .Leaderboard__loading {
+  .TeamLeaderboard__loading {
     @extend %ehw-tile-loading-icon;
   }
 }

--- a/src/components/leaderboards/TeamLeaderboardItem/index.js
+++ b/src/components/leaderboards/TeamLeaderboardItem/index.js
@@ -5,9 +5,25 @@ var React = require('react');
 module.exports = React.createClass({
   displayName: 'TeamLeaderboardItem',
 
+  propTypes: {
+    imgSrc: React.PropTypes.string.isRequired,
+    url: React.PropTypes.string.isRequired,
+    totalMembers: React.PropTypes.number.isRequired,
+    name: React.PropTypes.string.isRequired,
+    isoCode: React.PropTypes.string.isRequired,
+    amount: React.PropTypes.string.isRequired,
+    raisedTitle: React.PropTypes.string.isRequired,
+    membersTitle: React.PropTypes.string.isRequired,
+    width: React.PropTypes.string.isRequired
+  },
+
   render: function() {
+    var style = {
+      width: this.props.width
+    };
+
     return (
-      <li className="TeamLeaderboard__items-item">
+      <li className="TeamLeaderboard__items-item" style={ style }>
         <div className="TeamLeaderboard__items-skin">
           <a href={ this.props.url } className="TeamLeaderboard__items-image">
             <img src={ this.props.imgSrc } />

--- a/src/components/leaderboards/TeamLeaderboardItem/style.scss
+++ b/src/components/leaderboards/TeamLeaderboardItem/style.scss
@@ -2,16 +2,7 @@
   box-sizing: border-box;
   display: block;
   padding: 0 10px 15px;
-  width: 25%;
   float: left;
-
-  @include media-max($breakpoint-l) {
-    width: 50%;
-  }
-
-  @include media-max($breakpoint-s) {
-    width: 100%;
-  }
 
   .TeamLeaderboard__items-skin {
     @extend %clearfix;
@@ -24,11 +15,6 @@
 .TeamLeaderboard__items-content {
   box-sizing: border-box;
   padding: 15px;
-
-  @include media-max($breakpoint-l) {
-    width: 50%;
-    float: left;
-  }
 }
 
 .TeamLeaderboard__items-name {
@@ -52,12 +38,6 @@
     width:100%;
     border: 0;
   }
-
-  @include media-max($breakpoint-l) {
-    width: 50%;
-    float: left;
-    padding: 15px;
-  }
 }
 
 .TeamLeaderboard__items-stats {
@@ -71,10 +51,6 @@
     width: 50%;
     padding: 10px;
     text-align: center;
-
-    @include media-max($breakpoint-l) {
-      padding: 0;
-    }
   }
 
   .TeamLeaderboard__items-stat-content {
@@ -84,14 +60,6 @@
   .TeamLeaderboard__items-stat-title {
     text-transform: uppercase;
     font-size: 13px;
-
-    @include media-max($breakpoint-xl) {
-      font-size: 11px;
-    }
-
-    @include media-max($breakpoint-l) {
-      font-size: 10px;
-    }
   }
 
   .TeamLeaderboard__items-stat:first-child {

--- a/src/components/leaderboards/TeamLeaderboardItem/style.scss
+++ b/src/components/leaderboards/TeamLeaderboardItem/style.scss
@@ -66,3 +66,21 @@
     border-right: 1px solid $ehw-grey-dark;
   }
 }
+
+.TeamLeaderboard__animation-enter {
+  opacity: 0.01;
+  transition: opacity .66s ease-in;
+}
+
+.TeamLeaderboard__animation-enter-active {
+  opacity: 1;
+}
+
+// pull existing items out of view immediately
+.TeamLeaderboard__animation-leave {
+  position: absolute;
+  top: -999px;
+  left: -999px;
+  opacity: 0;
+  transition: all .1s ease-in;
+}

--- a/src/components/mixins/Leaderboard.js
+++ b/src/components/mixins/Leaderboard.js
@@ -1,0 +1,128 @@
+"use strict";
+
+var _                 = require('lodash');
+var React             = require('react');
+var cx                = require('react/lib/cx');
+var Icon              = require('../helpers/Icon');
+var numeral           = require('numeral');
+var campaigns         = require('../../api/campaigns');
+var charities         = require('../../api/charities');
+var LeaderboardPaging = require('../leaderboards/LeaderboardPaging');
+
+module.exports = {
+  componentWillMount: function() {
+    this.loadLeaderboard();
+  },
+
+  getEndpoint: function() {
+    var endpoint;
+    var props = this.props;
+
+    if (props.country) {
+      if (props.campaignSlug) { endpoint = campaigns.leaderboardBySlug.bind(campaigns, props.country, props.campaignSlug); }
+      if (props.charitySlug)  { endpoint = charities.leaderboardBySlug.bind(charities, props.country, props.charitySlug); }
+    } else {
+      if (props.campaignUid)  { endpoint = campaigns.leaderboard.bind(campaigns, props.campaignUid); }
+      if (props.charityUid)   { endpoint = charities.leaderboard.bind(charities, props.charityUid); }
+    }
+
+    if (!endpoint && console && console.log) {
+      console.log("Leaderboard widget requires 'campaignUid' or 'charityUid'. If 'country' is given then 'campaignSlug' or 'charitySlug' may be used instead. ");
+    }
+
+    return (endpoint || function(type, limit, callback) { callback(null); });
+  },
+
+  loadLeaderboard: function() {
+    this.setState({
+      isLoading: true
+    });
+
+    var endpoint = this.getEndpoint();
+    endpoint(this.props.type, this.props.limit, this.processLeaderboard, { includePages: true });
+  },
+
+  processLeaderboard: function(result) {
+    var pages = result && result.leaderboard && result.leaderboard.pages ? result.leaderboard.pages : [];
+    var leaderboard = _.map(pages, this.processPage);
+
+    this.rankLeaderboard(leaderboard);
+
+    this.setState({
+      isLoading: false,
+      boardData: this.paginateLeaderboard(leaderboard),
+      childWidth: this.getChildrenWidth(this.props.childWidth, this.props.pageSize)
+    });
+  },
+
+  processPage: function(page) {
+    return {
+      id: page.id,
+      name: page.name,
+      url: page.url,
+      isoCode: page.amount.currency.iso_code,
+      amount:  page.amount.cents,
+      totalMembers: page.team_member_uids.length,
+      imgSrc: page.image.large_image_url,
+      medImgSrc: page.image.medium_image_url
+    };
+  },
+
+  rankLeaderboard: function(leaderboard) {
+    var rank = 1;
+    var prevItem = null;
+
+    _.forEach(leaderboard, function(item, i) {
+      if (prevItem && item.amount != prevItem.amount) {
+        rank = i + 1;
+      }
+
+      item.rank = rank;
+      prevItem = item;
+    });
+  },
+
+  paginateLeaderboard: function(leaderboard) {
+    var pageSize         = this.props.pageSize;
+    var pagedLeaderboard = [];
+
+    for (var i = 0; i < leaderboard.length; i += pageSize) {
+      pagedLeaderboard.push(leaderboard.slice(i,i + pageSize));
+    }
+
+    return pagedLeaderboard;
+  },
+
+  formatAmount: function(amount) {
+    return this.t('symbol') + numeral(amount / 100).format(this.props.currencyFormat);
+  },
+
+  prevPage: function() {
+    if (this.state.currentPage > 1) {
+      this.setState({ currentPage: this.state.currentPage - 1 });
+    }
+  },
+
+  nextPage: function() {
+    var totalPages  = this.props.limit / this.props.pageSize;
+    var currentPage = this.state.currentPage;
+
+    if (currentPage < totalPages) {
+      this.setState({ currentPage: currentPage + 1 });
+    }
+  },
+
+  renderPaging: function() {
+    var pageCount = this.props.limit / this.props.pageSize;
+
+    if (!this.state.isLoading) {
+      return (
+        <LeaderboardPaging
+          nextPage={ this.nextPage }
+          prevPage={ this.prevPage }
+          currentPage={ this.state.currentPage }
+          pageCount={ pageCount } />
+      );
+    }
+  }
+};

--- a/src/components/mixins/Leaderboard.js
+++ b/src/components/mixins/Leaderboard.js
@@ -115,7 +115,7 @@ module.exports = {
   renderPaging: function() {
     var pageCount = this.props.limit / this.props.pageSize;
 
-    if (!this.state.isLoading) {
+    if (!this.state.isLoading && pageCount > 1) {
       return (
         <LeaderboardPaging
           nextPage={ this.nextPage }

--- a/src/components/mixins/Leaderboard.js
+++ b/src/components/mixins/Leaderboard.js
@@ -10,10 +10,6 @@ var charities         = require('../../api/charities');
 var LeaderboardPaging = require('../leaderboards/LeaderboardPaging');
 
 module.exports = {
-  componentWillMount: function() {
-    this.loadLeaderboard();
-  },
-
   getEndpoint: function() {
     var endpoint;
     var props = this.props;
@@ -33,13 +29,13 @@ module.exports = {
     return (endpoint || function(type, limit, callback) { callback(null); });
   },
 
-  loadLeaderboard: function() {
+  loadLeaderboard: function(type) {
     this.setState({
       isLoading: true
     });
 
     var endpoint = this.getEndpoint();
-    endpoint(this.props.type, this.props.limit, this.processLeaderboard, { includePages: true });
+    endpoint(type, this.props.limit, this.processLeaderboard, { includePages: true });
   },
 
   processLeaderboard: function(result) {

--- a/src/index.html
+++ b/src/index.html
@@ -214,7 +214,7 @@
     edh.widgets.renderWidget('GoalExample', 'Goal', { goal: '5000000', i18n: { title: '2015 Goal' } });
     edh.widgets.renderWidget('CountDownExample', 'CountDown', { days: 34, registerUrl: 'https://pmhincelebration.edheroy.com/au/get-started' });
     edh.widgets.renderWidget('LeaderboardExample', 'Leaderboard', { campaignUid: 'us-22' });
-    edh.widgets.renderWidget('TeamLeaderboardExample', 'Leaderboard', { campaignUid: 'us-22', type: 'team', limit: 16, pageSize: 4, i18n: { heading: 'Leaderboard > Top Teams' } });
+    edh.widgets.renderWidget('TeamLeaderboardExample', 'TeamLeaderboard', { campaignUid: 'us-22' });
     edh.widgets.renderWidget('FitnessLeaderboardExample', 'FitnessLeaderboard', { campaignUid: 'us-22' });
     edh.widgets.renderWidget('UpcomingEventsExample','UpcomingEvents', { charityUid: 'gb-1', charitySlug: 'walk-the-walk' });
     edh.widgets.renderWidget('RecentFundraisersExample', 'RecentFundraisers', { campaignUid: 'us-22' });

--- a/src/index.html
+++ b/src/index.html
@@ -214,7 +214,7 @@
     edh.widgets.renderWidget('GoalExample', 'Goal', { goal: '5000000', i18n: { title: '2015 Goal' } });
     edh.widgets.renderWidget('CountDownExample', 'CountDown', { days: 34, registerUrl: 'https://pmhincelebration.edheroy.com/au/get-started' });
     edh.widgets.renderWidget('LeaderboardExample', 'Leaderboard', { campaignUid: 'us-22' });
-    edh.widgets.renderWidget('TeamLeaderboardExample', 'TeamLeaderboard', { campaignUid: 'us-22' });
+    edh.widgets.renderWidget('TeamLeaderboardExample', 'TeamLeaderboard', { campaignUid: 'us-22', altTemplate: true, limit: 12, pageSize: 4 });
     edh.widgets.renderWidget('FitnessLeaderboardExample', 'FitnessLeaderboard', { campaignUid: 'us-22' });
     edh.widgets.renderWidget('UpcomingEventsExample','UpcomingEvents', { charityUid: 'gb-1', charitySlug: 'walk-the-walk' });
     edh.widgets.renderWidget('RecentFundraisersExample', 'RecentFundraisers', { campaignUid: 'us-22' });

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -15,6 +15,8 @@ var widgets = {
   Goal: require('./components/totals/Goal'),
   GoalProgress: require('./components/totals/GoalProgress'),
   Leaderboard: require('./components/leaderboards/Leaderboard'),
+  TeamLeaderboard: require('./components/leaderboards/TeamLeaderboard'),
+  LeaderboardPaging: require('./components/leaderboards/LeaderboardPaging'),
   FitnessLeaderboard: require('./components/leaderboards/FitnessLeaderboard'),
   UpcomingEvents: require('./components/events/UpcomingEvents'),
   Event: require('./components/events/Event'),

--- a/src/widgets.scss
+++ b/src/widgets.scss
@@ -21,7 +21,9 @@
 @import "components/totals/TotalHours/style";
 @import "components/leaderboards/LeaderboardItem/style";
 @import "components/leaderboards/Leaderboard/style";
+@import "components/leaderboards/TeamLeaderboard/style";
 @import "components/leaderboards/TeamLeaderboardItem/style";
+@import "components/leaderboards/LeaderboardPaging/style";
 @import "components/fundraisers/RecentFundraisers/style";
 @import "components/fundraisers/FundraiserImage/style";
 @import "components/teams/Teams/style";

--- a/src/widgets.scss
+++ b/src/widgets.scss
@@ -24,6 +24,7 @@
 @import "components/leaderboards/TeamLeaderboard/style";
 @import "components/leaderboards/TeamLeaderboardItem/style";
 @import "components/leaderboards/LeaderboardPaging/style";
+@import "components/leaderboards/LeaderboardPagingButton/style";
 @import "components/fundraisers/RecentFundraisers/style";
 @import "components/fundraisers/FundraiserImage/style";
 @import "components/teams/Teams/style";


### PR DESCRIPTION
![screen shot 2015-03-19 at 11 09 47 am](https://cloud.githubusercontent.com/assets/859298/6722611/82ce60d0-ce28-11e4-8380-27cffcc8ef07.png)



- Switched to using JS to determine sub-component width rather than relying on pure media queries. (using DOMInfo mixin).

- Split Leaderboard component in to two separate components (Leaderboard and TeamLeaderboard). This is to deal with an issue with JS resize event listener, related to above.

- Most shared logic for leaderboards is now pushed in to a leaderboard mixin.

- The paging buttons have been spruced up and split out in to a new component LeaderboardPaging.

- The default team leaderboard render markup has been changed to the same as individual leaderboards, but the original style is still available by setting a prop `altTemplate` to `true`.

- Simple fade transition added between pages.