### PR TITLE
PR [TA-5345] Add Charity Search visit action

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The charity search modal widget allows you to search for a charity by name to do
 
 ##### Options
 
-- `action`: *required* action to perform on charity select, either 'donate', 'fundraise' or 'custom'. *Note: 'donate' action is currently not supported for country 'us'.*
+- `action`: *optional* action to perform on charity select, either 'visit' (default), 'donate', 'fundraise', or 'custom'. *Note: 'visit' and 'donate' actions are currently not supported for country 'us'.*
 - `onSelect`: *optional* function called on selecting a result when `action` set to 'custom'.
 - `campaignUid`: *optional* string campaign uid to filter charity results.
 - `campaignSlug`: *optional* string campaign slug for given campaign uid.
@@ -54,6 +54,7 @@ The charity search modal widget allows you to search for a charity by name to do
   ```js
   {
     title: 'Search for a Charity',
+    visitAction: 'Visit Charity',
     donateAction: 'Give to this Charity',
     fundraiseAction: 'Fundraise for this Charity',
     selectAction: 'Select',
@@ -73,9 +74,9 @@ The charity search modal widget allows you to search for a charity by name to do
     <script src="//d1ig6folwd6a9s.cloudfront.net/widgets-[0.0.0].js"></script>
   </head>
   <body>
-    <a id="CharitySearchExample">Support a Charity</a>
+    <a id="CharitySearchExample">Find a Charity</a>
     <script>
-      edh.widgets.initModal('CharitySearchExample', 'CharitySearch', { country: 'uk', action: 'donate' });
+      edh.widgets.initModal('CharitySearchExample', 'CharitySearch', { country: 'uk' });
     </script>
   </body>
 </html>

--- a/src/components/search/CharitySearchModal/__tests__/CharitySearchModal-test.js
+++ b/src/components/search/CharitySearchModal/__tests__/CharitySearchModal-test.js
@@ -25,7 +25,8 @@ var charity = {
   slug: 'foo',
   name: 'Foo',
   description: 'Fooy',
-  country_code: 'xy'
+  country_code: 'xy',
+  url: 'http://foo.com/'
 };
 
 var charity2 = {
@@ -33,7 +34,8 @@ var charity2 = {
   slug: 'bar',
   name: 'Bar',
   description: 'Bary',
-  country_code: 'xy'
+  country_code: 'xy',
+  url: 'http://bar.com/'
 };
 
 var searchResponse = {
@@ -79,7 +81,7 @@ describe('CharitySearchModal', function() {
 
   it('search for all charities when search is empty', function() {
     var query = { country: 'xy', searchTerm: '', campaignUid: '', page: 1, pageSize: 10 };
-    var charitySearchModal = <CharitySearchModal autoFocus={ false } action="donate" country="xy"/>;
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } country="xy"/>;
     var element = TestUtils.renderIntoDocument(charitySearchModal);
 
     expect(charities.search).lastCalledWith(query, element.updateResults);
@@ -87,7 +89,7 @@ describe('CharitySearchModal', function() {
 
   it('searches for charities within campaign', function() {
     var query = { country: 'xy', searchTerm: '', campaignUid: 'xy-123', page: 1, pageSize: 10 };
-    var charitySearchModal = <CharitySearchModal autoFocus={ false } action="donate" country="xy" campaignUid="xy-123" />;
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } country="xy" campaignUid="xy-123" />;
     var element = TestUtils.renderIntoDocument(charitySearchModal);
 
     expect(charities.search).lastCalledWith(query, element.updateResults);
@@ -95,7 +97,7 @@ describe('CharitySearchModal', function() {
 
   it('searches for charities on input change', function() {
     var query = { country: 'xy', searchTerm: 'foo', campaignUid: '', page: 1, pageSize: 10 };
-    var charitySearchModal = <CharitySearchModal autoFocus={ false } action="donate" country="xy" />;
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } country="xy" />;
     var element = TestUtils.renderIntoDocument(charitySearchModal);
     var input = findByTag(element, 'input');
     TestUtils.Simulate.change(input, { target: { value: 'foo' } });
@@ -108,7 +110,7 @@ describe('CharitySearchModal', function() {
     charities.search.mockImplementation(function(query, callback) { callback(searchResponse); });
 
     var query = { country: 'xy', searchTerm: '', campaignUid: '', page: 2, pageSize: 10 };
-    var charitySearchModal = <CharitySearchModal autoFocus={ false } action="donate" country="xy" />;
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } country="xy" />;
     var element = TestUtils.renderIntoDocument(charitySearchModal);
     var nextPageButton = findByClass(element, 'SearchPagination__button--right');
     TestUtils.Simulate.click(nextPageButton);
@@ -126,7 +128,7 @@ describe('CharitySearchModal', function() {
   });
 
   it('updates isSearching accordingly', function() {
-    var charitySearchModal = <CharitySearchModal autoFocus={ false } action="donate" country="xy" />;
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } country="xy" />;
     var element = TestUtils.renderIntoDocument(charitySearchModal);
 
     expect(element.state.isSearching).toBeTruthy();
@@ -140,6 +142,17 @@ describe('CharitySearchModal', function() {
     TestUtils.Simulate.change(input, { target: { value: 'foo' } });
 
     expect(element.state.isSearching).toBeTruthy();
+  });
+
+  it('links to charity url for default visit action', function() {
+    var onClose = jest.genMockFunction();
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } onClose={ onClose } />;
+    var element = TestUtils.renderIntoDocument(charitySearchModal);
+    element.setState({ results: [charity] });
+
+    var resultElements = scryByClass(element, 'SearchResult');
+
+    expect(resultElements[0].getDOMNode().href).toBe(charity.url);
   });
 
   it('links to fundraise url for fundraise action', function() {

--- a/src/components/search/CharitySearchModal/index.js
+++ b/src/components/search/CharitySearchModal/index.js
@@ -14,7 +14,7 @@ module.exports = React.createClass({
   mixins: [I18nMixin],
 
   propTypes: {
-    action: React.PropTypes.oneOf(['donate', 'fundraise', 'custom']).isRequired,
+    action: React.PropTypes.oneOf(['visit', 'donate', 'fundraise', 'custom']),
     autoFocus: React.PropTypes.bool,
     campaignUid: React.PropTypes.string,
     campaignSlug: React.PropTypes.string,
@@ -27,11 +27,13 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
+      action: 'visit',
       autoFocus: true,
       campaignUid: '',
       campaignSlug: null,
       defaultI18n: {
         title: 'Search for a Charity',
+        visitAction: 'Visit Charity',
         donateAction: 'Give to this Charity',
         fundraiseAction: 'Fundraise for this Charity',
         emptyLabel: "We couldn't find any matching Charities."
@@ -132,7 +134,7 @@ module.exports = React.createClass({
   },
 
   hasCustomHandler: function() {
-    return this.props.action == 'custom';
+    return this.props.action == 'custom' && this.props.onSelect;
   },
 
   customHandler: function(result) {
@@ -155,7 +157,7 @@ module.exports = React.createClass({
       return {
         id: charity.id,
         charity: charity,
-        url: resultUrl && resultUrl(charity, props.campaignSlug)
+        url: resultUrl ? resultUrl(charity, props.campaignSlug) : charity.url
       };
     });
   },

--- a/src/index.html
+++ b/src/index.html
@@ -144,9 +144,10 @@
     <div class="main-content pull-left">
       <div class="panel clearfix">
         <h3 class="title">Search</h3>
+        <a id="CharitySearchVisit" class="modal"><i class="Icon fa fa-heart fa-fw"></i> Find a Charity</a>
         <a id="CharitySearchDonate" class="modal"><i class="Icon fa fa-money fa-fw"></i> Donate to a Charity</a>
         <a id="CharitySearchFundraise" class="modal"><i class="Icon fa fa-bolt fa-fw"></i> Fundraise for a Charity</a>
-        <a id="PageSearchExample" class="modal"><i class="Icon fa fa-heart fa-fw"></i> Support a Friend</a>
+        <a id="PageSearchExample" class="modal"><i class="Icon fa fa-group fa-fw"></i> Support a Friend</a>
       </div>
 
       <div class="panel clearfix">
@@ -204,6 +205,7 @@
   </div>
 
   <script>
+    edh.widgets.initModal('CharitySearchVisit', 'CharitySearch', { country: 'uk' });
     edh.widgets.initModal('CharitySearchDonate', 'CharitySearch', { country: 'uk', action: 'donate' });
     edh.widgets.initModal('CharitySearchFundraise', 'CharitySearch', { country: 'uk', action: 'fundraise' });
     edh.widgets.initModal('PageSearchExample', 'PageSearch', { country: 'uk' });


### PR DESCRIPTION
https://edhdev.atlassian.net/browse/TA-5345

- Charity Search Modal now lets you visit the charity profile page.
- Uses 'url' property in charity search response.
- Supporter needs to be updated to return new charity profile app url for Ireland charities.

![screen shot 2015-03-23 at 11 46 10 am](https://cloud.githubusercontent.com/assets/1740899/6772821/39934548-d152-11e4-82bb-41d537101f67.png)
![screen shot 2015-03-23 at 11 47 13 am](https://cloud.githubusercontent.com/assets/1740899/6772822/3996de06-d152-11e4-89dd-a96a86405a0f.png)
