### PR TITLE
Fix overflow scrolling issue.

### DIFF
--- a/src/components/search/SearchModal/style.scss
+++ b/src/components/search/SearchModal/style.scss
@@ -29,7 +29,6 @@
   top: 117px;
   right: 0px;
   padding: $x-9;
-  overflow-y: scroll;
   overflow-x: hidden;
   transition: all 0.3s;
   -webkit-overflow-scrolling: touch;

--- a/src/components/search/SearchResults/style.scss
+++ b/src/components/search/SearchResults/style.scss
@@ -9,6 +9,7 @@
   };
   width: 100%;
   max-width: $x-229;
+  overflow-y: scroll;
 }
 
 .SearchResults--empty {


### PR DESCRIPTION
Scrolling is broken is the search modals. To see:

1. Go to: https://shared-scripts.s3.amazonaws.com/widgets-0.2.3.html
2. Type "an" to see some results.
3. With a short browser window try scrolling through results.

To fix I just moved the `overflow-y: scroll;` down a level.

