### PR TITLE
Move click listener to document. Fix visual bugs with inputs in ie.

### DIFF
--- a/src/components/forms/Input/style.scss
+++ b/src/components/forms/Input/style.scss
@@ -43,7 +43,7 @@
   min-height: 27px;
 
   &::-ms-clear {
-    width : 0;
+    width: 0;
     height: 0;
   }
 }

--- a/src/components/forms/Input/style.scss
+++ b/src/components/forms/Input/style.scss
@@ -40,6 +40,12 @@
   text-transform: none;
   letter-spacing: 0.05em;
   line-height: 27px;
+  min-height: 27px;
+
+  &::-ms-clear {
+    width : 0;
+    height: 0;
+  }
 }
 
 .Input__message {

--- a/src/components/sharing/ShareButton/index.js
+++ b/src/components/sharing/ShareButton/index.js
@@ -63,12 +63,12 @@ module.exports = React.createClass({
 
   open: function() {
     this.setState({ open: true });
-    addEventListener('click', this.close);
+    addEventListener('click', this.close, document);
   },
 
   close: function() {
     this.setState({ open: false });
-    removeEventListener('click', this.close);
+    removeEventListener('click', this.close, document);
   },
 
   filterServices: function() {


### PR DESCRIPTION
Moved the click listener to `document` as having it on `window` was causing some weird issue with the tooltip/share box closing immediately after opening.

Also made some minor changes to to the Input component to fix the below bugs found in IE9 and 10.

![screen shot 2015-04-08 at 10 30 15 pm](https://cloud.githubusercontent.com/assets/859298/7045209/16607254-de3f-11e4-8705-7eba083a79f2.png)

![screen shot 2015-04-08 at 10 16 38 pm](https://cloud.githubusercontent.com/assets/859298/7045124/3f3963c6-de3e-11e4-9f3a-0855d9ac002c.png)
![screen shot 2015-04-08 at 10 16 21 pm](https://cloud.githubusercontent.com/assets/859298/7045125/3f3b0ac8-de3e-11e4-8855-409f235feffd.png)
