### PR TITLE
Add numeral formatting to string format

### DIFF
--- a/src/lib/__tests__/format-test.js
+++ b/src/lib/__tests__/format-test.js
@@ -1,0 +1,22 @@
+"use strict";
+jest.autoMockOff();
+
+var format = require('../format');
+
+describe('format', function() {
+  it('interpolates params', function() {
+    expect(format('Hello {name}!', {name: 'World'})).toBe('Hello World!');
+  });
+
+  it('strips placeholders when requested', function() {
+    expect(format('Hello {name}!', null, true)).toBe('Hello !');
+  });
+
+  it('does not strip placeholders when not requested', function() {
+    expect(format('Hello {name}!')).toBe('Hello {name}!');
+  });
+
+  it('supports numeral placeholder formatting', function() {
+    expect(format('{count:0,0}', {count: 1234567890})).toBe('1,234,567,890');
+  });
+});

--- a/src/lib/format.js
+++ b/src/lib/format.js
@@ -1,13 +1,23 @@
 "use strict";
 
+var numeral = require('numeral');
+
 function format(template, data, strip) {
-  if (!data) {
+  if (!data && !strip) {
     return template;
   }
 
+  data = data || {};
+
   return template.replace(/{([^{}]+)}/g, function(a, b) {
-    var r = data[b];
-    return (r !== null && r !== undefined) ? r : strip ? '' : a;
+    var parts = b.split(':');
+    var format = parts[1];
+    var key = parts[0];
+    var value = data[key];
+    if (value == null) {
+      return strip ? '' : a;
+    }
+    return format ? numeral(value).format(format) : value;
   });
 }
 


### PR DESCRIPTION
eg `format('{count:0,0} supporters', {count: 1234567})` returns `1,234,567 supporters`.

- Can now provide optional numeral format for numeric placeholders.
- Anything after the optional `:` is a format string for [numeraljs](http://numeraljs.com/).
- Currently only works for numeric values but can be extended for string params.
- This is very useful in i18n text and saves having to preformat numeric values before string interpolation.
- Fixes issue with i18n pluralisation when providing `count` param to select correct string but wanting to format the `count` param.