### PR TITLE
Update totals widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,14 +182,16 @@ edh.widgets.renderWidget(element, name, options)
 
 #### Funds Raised
 
-Displays the total funds raised for specified campaigns or page as a dollar amount. Either a single or multiple campaign uids OR a single page id can be provided to scope this widget.
+Displays the total funds raised for specified campaigns, pages or charities as a dollar amount. Either a single or multiple campaign/page/charity ids can be provided as parameters to scope this widget.
 
 ##### Options
 
 - `campaignUid`: *optional* string campaign uid to filter results by campaign.
 - `campaignUids`: *optional* array of campaign uids to filter results by multiple campaigns.
 - `pageId`: *optional* string page id to filter results by page.
+- `pageId`: *optional* array of page ids to filter results by multiple pages.
 - `charityUid`: *optional* string charity uid to filter results by charity.
+- `charityUids`: *optional* array of charity uids to filter results by multiple charities.
 - `renderIcon`: *optional* boolean. Set to `true` by default.
 - `offset`: *optional* number. Set to `0` by default.
 - `backgroundColor`: *optional* string. Not set by default.

--- a/src/api/__tests__/totals-test.js
+++ b/src/api/__tests__/totals-test.js
@@ -19,7 +19,20 @@ describe('totals', function() {
       var callback = jest.genMockFunction();
       totals.findByCampaign('us-22', callback);
 
-      expect(getJSONP).lastCalledWith('https://everydayhero.com/api/v2/search/totals.jsonp?campaign_id=us-22', callback);
+      expect(getJSONP).lastCalledWith('https://everydayhero.com/api/v2/search/totals.jsonp?campaign_id[]=us-22', callback);
+      expect(callback).toBeCalledWith(results);
+      expect(callback.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('findByCampaigns', function() {
+    it('gets total from multiple campaign uids', function() {
+      var callback = jest.genMockFunction();
+      totals.findByCampaigns(['xx-123','yy-123'], callback);
+
+      expect(getJSONP).lastCalledWith(
+        'https://everydayhero.com/api/v2/search/totals.jsonp?campaign_id[]=xx-123&campaign_id[]=yy-123', callback
+      );
       expect(callback).toBeCalledWith(results);
       expect(callback.mock.calls.length).toBe(1);
     });

--- a/src/api/__tests__/totals-test.js
+++ b/src/api/__tests__/totals-test.js
@@ -14,18 +14,16 @@ describe('totals', function() {
     getJSONP.mockClear();
   });
 
-  describe('findByCampaign', function() {
+  describe('findByCampaigns', function() {
     it('gets total from campaign id', function() {
       var callback = jest.genMockFunction();
-      totals.findByCampaign('us-22', callback);
+      totals.findByCampaigns('us-22', callback);
 
       expect(getJSONP).lastCalledWith('https://everydayhero.com/api/v2/search/totals.jsonp?campaign_id[]=us-22', callback);
       expect(callback).toBeCalledWith(results);
       expect(callback.mock.calls.length).toBe(1);
     });
-  });
 
-  describe('findByCampaigns', function() {
     it('gets total from multiple campaign uids', function() {
       var callback = jest.genMockFunction();
       totals.findByCampaigns(['xx-123','yy-123'], callback);
@@ -41,9 +39,9 @@ describe('totals', function() {
   describe('findByPage', function() {
     it('gets total from page id', function() {
       var callback = jest.genMockFunction();
-      totals.findByPage('848751', callback);
+      totals.findByPages('848751', callback);
 
-      expect(getJSONP).lastCalledWith('https://everydayhero.com/api/v2/search/totals.jsonp?page_id=848751', callback);
+      expect(getJSONP).lastCalledWith('https://everydayhero.com/api/v2/search/totals.jsonp?page_id[]=848751', callback);
       expect(callback).toBeCalledWith(results);
       expect(callback.mock.calls.length).toBe(1);
     });
@@ -52,9 +50,9 @@ describe('totals', function() {
   describe('findByCharity', function() {
     it('gets total from charity id', function() {
       var callback = jest.genMockFunction();
-      totals.findByCharity('au-31', callback);
+      totals.findByCharities('au-31', callback);
 
-      expect(getJSONP).lastCalledWith('https://everydayhero.com/api/v2/search/totals.jsonp?charity_id=au-31', callback);
+      expect(getJSONP).lastCalledWith('https://everydayhero.com/api/v2/search/totals.jsonp?charity_id[]=au-31', callback);
       expect(callback).toBeCalledWith(results);
       expect(callback.mock.calls.length).toBe(1);
     });

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -25,12 +25,12 @@ var baseRoutes = {
 
   address:              '{baseUrl}/api/v2/addresses/{country}/{id}.jsonp',
   searchAddresses:      '{baseUrl}/api/v2/addresses.jsonp?country_code={country}&q={searchTerm}',
-  totals:               '{baseUrl}/api/v2/search/totals.jsonp?charity_id={charityUid}&campaign_id={campaignUid}&page_id={page}&start_at={start}&end_at={end}&kind={type}&country_code={country}'
+  totals:               '{baseUrl}/api/v2/search/totals.jsonp?charity_id={charityUid}&campaign_id[]={campaignUid}&page_id={page}&start_at={start}&end_at={end}&kind={type}&country_code={country}'
 };
 var routes = {};
 
 function removeEmptyQueryParams(url) {
-  return url.replace(/\w+=(&|$)/g, '').replace(/(\?|&)$/, '');
+  return url.replace(/\w+(?:\W+|)=(&|$)/g, '').replace(/(\?|&)$/, '');
 }
 
 function getRoute(name, params) {

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -25,7 +25,7 @@ var baseRoutes = {
 
   address:              '{baseUrl}/api/v2/addresses/{country}/{id}.jsonp',
   searchAddresses:      '{baseUrl}/api/v2/addresses.jsonp?country_code={country}&q={searchTerm}',
-  totals:               '{baseUrl}/api/v2/search/totals.jsonp?charity_id={charityUid}&campaign_id[]={campaignUid}&page_id={page}&start_at={start}&end_at={end}&kind={type}&country_code={country}'
+  totals:               '{baseUrl}/api/v2/search/totals.jsonp?charity_id[]={charityUid}&campaign_id[]={campaignUid}&page_id[]={page}&start_at={start}&end_at={end}&kind={type}&country_code={country}'
 };
 var routes = {};
 

--- a/src/api/totals.js
+++ b/src/api/totals.js
@@ -10,6 +10,12 @@ module.exports = {
     return getJSONP(routes.get('totals', params), callback);
   },
 
+  findByCampaigns: function(campaignUids, callback) {
+    var uids = campaignUids.length > 1 ? campaignUids.join('&campaign_id[]=') : campaignUids[0];
+    var params = _.merge({ campaignUid: uids });
+    return getJSONP(routes.get('totals', params), callback);
+  },
+
   findByPage: function(pageId, callback, options) {
     var params = _.merge({ page: pageId }, options);
     return getJSONP(routes.get('totals', params), callback);

--- a/src/api/totals.js
+++ b/src/api/totals.js
@@ -4,25 +4,27 @@ var _        = require('lodash');
 var routes   = require('./routes');
 var getJSONP = require('../lib/getJSONP');
 
+function customJoin(ids, joinString) {
+  ids = _.isString(ids) ? [ids] : ids;
+  return ids.length > 1 ? ids.join(joinString) : ids[0];
+}
+
 module.exports = {
-  findByCampaign: function(campaignUid, callback, options) {
-    var params = _.merge({ campaignUid: campaignUid }, options);
-    return getJSONP(routes.get('totals', params), callback);
-  },
-
   findByCampaigns: function(campaignUids, callback) {
-    var uids = campaignUids.length > 1 ? campaignUids.join('&campaign_id[]=') : campaignUids[0];
-    var params = _.merge({ campaignUid: uids });
+    campaignUids = customJoin(campaignUids, '&campaign_id[]=');
+    var params = _.merge({ campaignUid: campaignUids });
     return getJSONP(routes.get('totals', params), callback);
   },
 
-  findByPage: function(pageId, callback, options) {
-    var params = _.merge({ page: pageId }, options);
+  findByPages: function(pageIds, callback, options) {
+    pageIds = customJoin(pageIds, '&page_id[]=');
+    var params = _.merge({ page: pageIds }, options);
     return getJSONP(routes.get('totals', params), callback);
   },
 
-  findByCharity: function(charityUid, callback, options) {
-    var params = _.merge({ charityUid: charityUid }, options);
+  findByCharities: function(charityUids, callback, options) {
+    charityUids = customJoin(charityUids, '&charity_id[]=');
+    var params = _.merge({ charityUid: charityUids }, options);
     return getJSONP(routes.get('totals', params), callback);
   }
 };

--- a/src/components/totals/FundsRaised/__tests__/FundsRaised-test.js
+++ b/src/components/totals/FundsRaised/__tests__/FundsRaised-test.js
@@ -52,14 +52,14 @@ describe('FundsRaised', function() {
     var element;
 
     beforeEach(function() {
-      totals.findByCampaign.mockClear();
+      totals.findByCampaigns.mockClear();
       fundsRaised = <FundsRaised campaignUid="us-22" />;
       element = TestUtils.renderIntoDocument(fundsRaised);
     });
 
     it('handles a single campaign id', function() {
-      expect(totals.findByCampaign.mock.calls.length).toEqual(1);
-      expect(totals.findByCampaign).toBeCalledWith("us-22", element.onSuccess);
+      expect(totals.findByCampaigns.mock.calls.length).toEqual(1);
+      expect(totals.findByCampaigns).toBeCalledWith(["us-22"], element.onSuccess);
     });
   });
 
@@ -100,15 +100,14 @@ describe('FundsRaised', function() {
     var element;
 
     beforeEach(function() {
-      totals.findByCampaign.mockClear();
+      totals.findByCampaigns.mockClear();
       fundsRaised = <FundsRaised campaignUids={ ["us-22", "us-24"] } />;
       element = TestUtils.renderIntoDocument(fundsRaised);
     });
 
     it('handles a multiple campaign ids', function() {
-      expect(totals.findByCampaign.mock.calls.length).toEqual(2);
-      expect(totals.findByCampaign).toBeCalledWith("us-22", element.onSuccess);
-      expect(totals.findByCampaign).toBeCalledWith("us-24", element.onSuccess);
+      expect(totals.findByCampaigns.mock.calls.length).toEqual(1);
+      expect(totals.findByCampaigns).toBeCalledWith(["us-22", "us-24"], element.onSuccess);
     });
   });
 

--- a/src/components/totals/FundsRaised/__tests__/FundsRaised-test.js
+++ b/src/components/totals/FundsRaised/__tests__/FundsRaised-test.js
@@ -14,7 +14,7 @@ describe('FundsRaised', function() {
     var element;
 
     beforeEach(function() {
-      totals.findByCampaign.mockClear();
+      totals.findByCampaigns.mockClear();
       fundsRaised = <FundsRaised campaignUid="us-22" />;
       element = TestUtils.renderIntoDocument(fundsRaised);
     });
@@ -59,7 +59,7 @@ describe('FundsRaised', function() {
 
     it('handles a single campaign id', function() {
       expect(totals.findByCampaigns.mock.calls.length).toEqual(1);
-      expect(totals.findByCampaigns).toBeCalledWith(["us-22"], element.onSuccess);
+      expect(totals.findByCampaigns).toBeCalledWith("us-22", element.onSuccess);
     });
   });
 
@@ -68,14 +68,14 @@ describe('FundsRaised', function() {
     var element;
 
     beforeEach(function() {
-      totals.findByPage.mockClear();
+      totals.findByPages.mockClear();
       fundsRaised = <FundsRaised pageId="848751" />;
       element = TestUtils.renderIntoDocument(fundsRaised);
     });
 
     it('handles a single page id', function() {
-      expect(totals.findByPage.mock.calls.length).toEqual(1);
-      expect(totals.findByPage).toBeCalledWith("848751", element.onSuccess);
+      expect(totals.findByPages.mock.calls.length).toEqual(1);
+      expect(totals.findByPages).toBeCalledWith("848751", element.onSuccess);
     });
   });
 
@@ -84,14 +84,14 @@ describe('FundsRaised', function() {
     var element;
 
     beforeEach(function() {
-      totals.findByCharity.mockClear();
+      totals.findByCharities.mockClear();
       fundsRaised = <FundsRaised charityUid="au-31" />;
       element = TestUtils.renderIntoDocument(fundsRaised);
     });
 
     it('handles a single charity id', function() {
-      expect(totals.findByCharity.mock.calls.length).toEqual(1);
-      expect(totals.findByCharity).toBeCalledWith("au-31", element.onSuccess);
+      expect(totals.findByCharities.mock.calls.length).toEqual(1);
+      expect(totals.findByCharities).toBeCalledWith("au-31", element.onSuccess);
     });
   });
 

--- a/src/components/totals/FundsRaised/index.js
+++ b/src/components/totals/FundsRaised/index.js
@@ -14,7 +14,9 @@ module.exports = React.createClass({
     campaignUid: React.PropTypes.string,
     campaignUids: React.PropTypes.array,
     pageId: React.PropTypes.string,
+    pageIds: React.PropTypes.array,
     charityUid: React.PropTypes.string,
+    charityUids: React.PropTypes.array,
     offset: React.PropTypes.number,
     renderIcon: React.PropTypes.bool,
     backgroundColor: React.PropTypes.string,
@@ -25,10 +27,12 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
-      campaignUid: '',
-      campaignUids: [],
-      pageId: '',
-      charityUid: '',
+      campaignUid: null,
+      campaignUids: null,
+      pageId: null,
+      pageIds: null,
+      charityUid: null,
+      charityUids: null,
       offset: 0,
       renderIcon: true,
       backgroundColor: null,
@@ -52,48 +56,20 @@ module.exports = React.createClass({
     this.loadTotals();
   },
 
-  setUids: function() {
-    var campaignUids = [];
-
-    if (this.props.campaignUid) {
-      campaignUids.push(this.props.campaignUid);
-    } else {
-      campaignUids = this.props.campaignUids;
-    }
-
-    return campaignUids;
-  },
-
   loadTotals: function() {
     this.setState({ isLoading: true });
 
-    var props      = this.props;
-    var propsCount = 0;
+    var props        = this.props;
+    var campaignUids = props.campaignUid || props.campaignUids;
+    var charityUids  = props.charityUid || props.charityUids;
+    var pageIds      = props.pageId || props.pageIds;
 
-    if (props.pageId) {
-      propsCount++;
-    }
-    if (props.charityUid) {
-      propsCount++;
-    }
-    if (props.campaignUid) {
-      propsCount++;
-    }
-    if (props.campaignUids.length > 0) {
-      propsCount++;
-    }
-
-    if (propsCount > 1) {
-      console.log('Please specify either a pageId, charityUid or campaignUid(s).');
-      return;
-    }
-
-    if (props.pageId) {
-      totals.findByPage(props.pageId, this.onSuccess);
-    } else if (props.charityUid) {
-      totals.findByCharity(props.charityUid, this.onSuccess);
-    } else {
-      totals.findByCampaigns(this.setUids(), this.onSuccess);
+    if (pageIds) {
+      totals.findByPages(pageIds, this.onSuccess);
+    } else if (charityUids) {
+      totals.findByCharities(charityUids, this.onSuccess);
+    } else if (campaignUids) {
+      totals.findByCampaigns(campaignUids, this.onSuccess);
     }
   },
 
@@ -123,9 +99,7 @@ module.exports = React.createClass({
   },
 
   renderIcon: function() {
-    var renderIcon = this.props.renderIcon;
-
-    if (renderIcon) {
+    if (this.props.renderIcon) {
       return <Icon className="FundsRaised__icon" icon="money"/>;
     }
   },

--- a/src/components/totals/FundsRaised/index.js
+++ b/src/components/totals/FundsRaised/index.js
@@ -67,57 +67,48 @@ module.exports = React.createClass({
   loadTotals: function() {
     this.setState({ isLoading: true });
 
+    var props      = this.props;
     var propsCount = 0;
-    if (this.props.pageId) {
+
+    if (props.pageId) {
       propsCount++;
     }
-    if (this.props.charityUid) {
+    if (props.charityUid) {
       propsCount++;
     }
-    if (this.props.campaignUid) {
+    if (props.campaignUid) {
       propsCount++;
     }
-    if (this.props.campaignUids.length > 0) {
+    if (props.campaignUids.length > 0) {
       propsCount++;
     }
 
     if (propsCount > 1) {
-      console.log('Please specify either a pageId, charityUid or a campaignUid.');
-      return false;
+      console.log('Please specify either a pageId, charityUid or campaignUid(s).');
+      return;
     }
 
-    if (this.props.pageId) {
-      totals.findByPage(this.props.pageId, this.onSuccess);
-    } else if (this.props.charityUid) {
-      totals.findByCharity(this.props.charityUid, this.onSuccess);
+    if (props.pageId) {
+      totals.findByPage(props.pageId, this.onSuccess);
+    } else if (props.charityUid) {
+      totals.findByCharity(props.charityUid, this.onSuccess);
     } else {
-      this.sumCampaigns(this.setUids());
+      totals.findByCampaigns(this.setUids(), this.onSuccess);
     }
-  },
-
-  sumCampaigns: function(campaignUids) {
-    for (var i = 0; i < campaignUids.length; i++) {
-      if (i === (campaignUids.length-1)) {
-        totals.findByCampaign(campaignUids[i], this.onSuccess);
-      } else {
-        totals.findByCampaign(campaignUids[i], this.onSuccessSum);
-      }
-    }
-  },
-
-  onSuccessSum: function(result) {
-    this.setState({total: this.state.total + result.total_amount_cents.sum});
   },
 
   onSuccess: function(result) {
-    this.setState({total: this.state.total + result.total_amount_cents.sum, isLoading: false});
+    this.setState({
+      total: this.state.total + result.total_amount_cents.sum,
+      isLoading: false
+    });
   },
 
   renderTotal: function() {
-    var symbol = this.t('symbol');
-    var totalDollars = (this.state.total + this.props.offset) / 100;
+    var symbol         = this.t('symbol');
+    var totalDollars   = (this.state.total + this.props.offset) / 100;
     var formattedTotal = symbol + numeral(totalDollars).format(this.props.format);
-    var title = this.t('title');
+    var title          = this.t('title');
 
     if (this.state.isLoading) {
       return <Icon className="FundsRaised__loading" icon="refresh" />;

--- a/src/components/totals/TotalDonations/__tests__/TotalDonations-test.js
+++ b/src/components/totals/TotalDonations/__tests__/TotalDonations-test.js
@@ -15,7 +15,7 @@ describe('TotalDonations', function() {
     var element;
 
     beforeEach(function() {
-      totals.findByCampaign.mockClear();
+      totals.findByCampaigns.mockClear();
       totalDonations = <TotalDonations campaignUid="us-22" />;
       element = TestUtils.renderIntoDocument(totalDonations);
     });
@@ -49,8 +49,8 @@ describe('TotalDonations', function() {
     });
 
     it('makes a single call using to fetch api data', function() {
-      expect(totals.findByCampaign.mock.calls.length).toEqual(1);
-      expect(totals.findByCampaign).toBeCalledWith("us-22", element.onSuccess);
+      expect(totals.findByCampaigns.mock.calls.length).toEqual(1);
+      expect(totals.findByCampaigns).toBeCalledWith("us-22", element.onSuccess);
     });
   });
 
@@ -59,15 +59,14 @@ describe('TotalDonations', function() {
     var element;
 
     beforeEach(function() {
-      totals.findByCampaign.mockClear();
+      totals.findByCampaigns.mockClear();
       totalDonations = <TotalDonations campaignUids={ ["us-22", "us-24"] } />;
       element = TestUtils.renderIntoDocument(totalDonations);
     });
 
     it('makes multiple calls to fetch api data', function() {
-      expect(totals.findByCampaign.mock.calls.length).toEqual(2);
-      expect(totals.findByCampaign).toBeCalledWith("us-22", element.onSuccess);
-      expect(totals.findByCampaign).toBeCalledWith("us-24", element.onSuccess);
+      expect(totals.findByCampaigns.mock.calls.length).toEqual(1);
+      expect(totals.findByCampaigns).toBeCalledWith(["us-22", "us-24"], element.onSuccess);
     });
   });
 

--- a/src/components/totals/TotalDonations/index.js
+++ b/src/components/totals/TotalDonations/index.js
@@ -22,8 +22,8 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
-      campaignUid: '',
-      campaignUids: [],
+      campaignUid: null,
+      campaignUids: null,
       renderIcon: true,
       backgroundColor: '',
       textColor: '',
@@ -67,12 +67,8 @@ module.exports = React.createClass({
   loadTotals: function() {
     this.setState({ isLoading: true });
 
-    var campaignUids = this.setUids();
-    var props = this.props;
-
-    _.each(campaignUids, function(campaignUid) {
-      totals.findByCampaign(campaignUid, this.onSuccess);
-    }, this);
+    var campaignUids = this.props.campaignUid || this.props.campaignUids;
+    totals.findByCampaigns(campaignUids, this.onSuccess);
   },
 
   renderTotal: function() {


### PR DESCRIPTION
- Add workaround to _totals.js_ to request multiple campaign/page/charity totals using one call. This fixes some extremely sketchy behaviour seen in making multiple calls to the totals endpoint in quick succession.
- Updated _totals.js_ to handle logic behind making an api call when handed a single id (string) or multiple ids (array).
- Add options to _FundsRaised_ component to accept multiple charity and page ids as parameters.