### PR TITLE
Make fundraisers and teams components support multiple campaign uids.

### DIFF
--- a/src/api/__tests__/pages-test.js
+++ b/src/api/__tests__/pages-test.js
@@ -70,25 +70,6 @@ describe('pages', function() {
     });
   });
 
-  describe('findByCampaigns', function() {
-    it('gets pages by campaign uids and type', function() {
-      var callback = jest.genMockFunction();
-      pages.findByCampaigns(['xy-12', 'xy-40', 'xy-33'], 'foo', 7, 2, callback);
-      expect(getJSONP).toBeCalled();
-      expect(getJSONP.mock.calls.length).toBe(3);
-      expect(getJSONP.mock.calls[0][0]).toContain('campaign_id=xy-12');
-      expect(getJSONP.mock.calls[1][0]).toContain('campaign_id=xy-40');
-      expect(getJSONP.mock.calls[2][0]).toContain('campaign_id=xy-33');
-      expect(callback.mock.calls.length).toBe(1);
-    });
-
-    it('accepts options', function() {
-      var callback = jest.genMockFunction();
-      pages.findByCampaigns('xy-12', 'foo', 7, 2, callback, { includeFootprint: true });
-      expect(getJSONP.mock.calls[0][0]).toContain('&include_footprint=true');
-    });
-  });
-
   describe('search', function() {
     it('searches for pages', function() {
       var query = { searchTerm: 'bar', country: 'xy', campaignUid: ['xy-12', 'xy-42'], charityUid: 'xy-123', type: 'foo', page: 2, pageSize: 7 };

--- a/src/api/__tests__/pages-test.js
+++ b/src/api/__tests__/pages-test.js
@@ -70,6 +70,25 @@ describe('pages', function() {
     });
   });
 
+  describe('findByCampaigns', function() {
+    it('gets pages by campaign uids and type', function() {
+      var callback = jest.genMockFunction();
+      pages.findByCampaigns(['xy-12', 'xy-40', 'xy-33'], 'foo', 7, 2, callback);
+      expect(getJSONP).toBeCalled();
+      expect(getJSONP.mock.calls.length).toBe(3);
+      expect(getJSONP.mock.calls[0][0]).toContain('campaign_id=xy-12');
+      expect(getJSONP.mock.calls[1][0]).toContain('campaign_id=xy-40');
+      expect(getJSONP.mock.calls[2][0]).toContain('campaign_id=xy-33');
+      expect(callback.mock.calls.length).toBe(1);
+    });
+
+    it('accepts options', function() {
+      var callback = jest.genMockFunction();
+      pages.findByCampaigns('xy-12', 'foo', 7, 2, callback, { includeFootprint: true });
+      expect(getJSONP.mock.calls[0][0]).toContain('&include_footprint=true');
+    });
+  });
+
   describe('search', function() {
     it('searches for pages', function() {
       var query = { searchTerm: 'bar', country: 'xy', campaignUid: ['xy-12', 'xy-42'], charityUid: 'xy-123', type: 'foo', page: 2, pageSize: 7 };

--- a/src/api/pages.js
+++ b/src/api/pages.js
@@ -1,8 +1,8 @@
 "use strict";
 
-var _ = require('lodash');
-var routes = require('./routes');
-var getJSONP = require('../lib/getJSONP');
+var _         = require('lodash');
+var routes    = require('./routes');
+var getJSONP  = require('../lib/getJSONP');
 var campaigns = require('./campaigns');
 
 module.exports = {
@@ -23,7 +23,34 @@ module.exports = {
       page: page,
       limit: limit
     }, options);
+
     return getJSONP(routes.get('pages', params), callback);
+  },
+
+  findByCampaigns: function(campaignUids, type, limit, page, callback, options) {
+    if (_.isEmpty(campaignUids)) {
+      _.defer(callback, { campaigns: [] });
+      return;
+    }
+
+    var pages = [];
+
+    var done = _.after(campaignUids.length, function() {
+      return callback({ pages: _.sample(pages, limit) });
+    });
+
+    var storePages = function(result) {
+      if ("pages" in result) {
+        _.forEach(result.pages, function(page) {
+          pages.push(page);
+        });
+      }
+      done();
+    };
+
+    _.forEach(campaignUids, function(campaignUid) {
+      this.findByCampaign(campaignUid, type, limit, page, storePages, options);
+    }, this);
   },
 
   search: function(params, callback) {

--- a/src/api/pages.js
+++ b/src/api/pages.js
@@ -27,32 +27,6 @@ module.exports = {
     return getJSONP(routes.get('pages', params), callback);
   },
 
-  findByCampaigns: function(campaignUids, type, limit, page, callback, options) {
-    if (_.isEmpty(campaignUids)) {
-      _.defer(callback, { campaigns: [] });
-      return;
-    }
-
-    var pages = [];
-
-    var done = _.after(campaignUids.length, function() {
-      return callback({ pages: _.sample(pages, limit) });
-    });
-
-    var storePages = function(result) {
-      if ("pages" in result) {
-        _.forEach(result.pages, function(page) {
-          pages.push(page);
-        });
-      }
-      done();
-    };
-
-    _.forEach(campaignUids, function(campaignUid) {
-      this.findByCampaign(campaignUid, type, limit, page, storePages, options);
-    }, this);
-  },
-
   search: function(params, callback) {
     params = _.merge({ page: 1, pageSize: 10 }, params);
     params.searchTerm = encodeURIComponent(params.searchTerm);

--- a/src/components/fundraisers/RecentFundraisers/__tests__/RecentFundraisers-test.js
+++ b/src/components/fundraisers/RecentFundraisers/__tests__/RecentFundraisers-test.js
@@ -45,7 +45,7 @@ describe('RecentFundraisers', function() {
     });
 
     it('renders if handed default campaign id, page type, count and size', function() {
-      expect(pages.findByCampaign).toBeCalledWith('au-0','individual','6','1', element.onSuccess);
+      expect(pages.findByCampaign).toBeCalledWith('au-0','individual', 6, 1, element.onSuccess);
     });
   });
 

--- a/src/components/fundraisers/RecentFundraisers/index.js
+++ b/src/components/fundraisers/RecentFundraisers/index.js
@@ -1,18 +1,20 @@
 "use strict";
 
-var _                 = require('lodash');
-var React             = require('react');
-var I18nMixin         = require('../../mixins/I18n');
-var pages             = require('../../../api/pages');
-var Icon              = require('../../helpers/Icon');
-var FundraiserImage   = require('../FundraiserImage');
+var _               = require('lodash');
+var React           = require('react');
+var I18nMixin       = require('../../mixins/I18n');
+var pages           = require('../../../api/pages');
+var Icon            = require('../../helpers/Icon');
+var FundraiserImage = require('../FundraiserImage');
 
 module.exports = React.createClass({
   mixins: [I18nMixin],
   displayName: "RecentFundraisers",
   propTypes: {
-    campaignUid: React.PropTypes.string,
-    campaignUids: React.PropTypes.array,
+    campaignUid: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.arrayOf(React.PropTypes.string)
+    ]),
     page: React.PropTypes.number,
     pageSize: React.PropTypes.number,
     renderIcon: React.PropTypes.bool,
@@ -21,6 +23,7 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
+      campaignUid: null,
       page: 1,
       pageSize: 6,
       type: 'individual',
@@ -48,12 +51,7 @@ module.exports = React.createClass({
     this.setState({ isLoading: true });
 
     var props = this.props;
-
-    if (props.campaignUids) {
-      pages.findByCampaigns(props.campaignUids, props.type, props.pageSize, props.page, this.onSuccess);
-    } else {
-      pages.findByCampaign(props.campaignUid, props.type, props.pageSize, props.page, this.onSuccess);
-    }
+    pages.findByCampaign(props.campaignUid, props.type, props.pageSize, props.page, this.onSuccess);
   },
 
   onSuccess: function(result) {

--- a/src/components/fundraisers/RecentFundraisers/index.js
+++ b/src/components/fundraisers/RecentFundraisers/index.js
@@ -12,17 +12,17 @@ module.exports = React.createClass({
   displayName: "RecentFundraisers",
   propTypes: {
     campaignUid: React.PropTypes.string,
-    page: React.PropTypes.string,
-    pageSize: React.PropTypes.string,
+    campaignUids: React.PropTypes.array,
+    page: React.PropTypes.number,
+    pageSize: React.PropTypes.number,
     renderIcon: React.PropTypes.bool,
     i18n: React.PropTypes.object
   },
 
   getDefaultProps: function() {
     return {
-      campaignUid: '',
-      page: '1',
-      pageSize: '6',
+      page: 1,
+      pageSize: 6,
       type: 'individual',
       backgroundColor: null,
       textColor: null,
@@ -41,13 +41,19 @@ module.exports = React.createClass({
   },
 
   componentWillMount: function() {
-    this.setState({
-      isLoading: true
-    });
+    this.loadPages();
+  },
+
+  loadPages: function() {
+    this.setState({ isLoading: true });
 
     var props = this.props;
 
-    pages.findByCampaign(props.campaignUid, props.type, props.pageSize, props.page, this.onSuccess);
+    if (props.campaignUids) {
+      pages.findByCampaigns(props.campaignUids, props.type, props.pageSize, props.page, this.onSuccess);
+    } else {
+      pages.findByCampaign(props.campaignUid, props.type, props.pageSize, props.page, this.onSuccess);
+    }
   },
 
   onSuccess: function(result) {

--- a/src/components/teams/Teams/index.js
+++ b/src/components/teams/Teams/index.js
@@ -11,11 +11,13 @@ module.exports = React.createClass({
   mixins: [I18nMixin],
   displayName: "Teams",
   propTypes: {
-    campaignUid: React.PropTypes.string,
-    campaignUids: React.PropTypes.array,
+    campaignUid: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.arrayOf(React.PropTypes.string)
+    ]),
     type: React.PropTypes.string,
-    page_count: React.PropTypes.number,
-    page_size: React.PropTypes.number,
+    page: React.PropTypes.number,
+    pageSize: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
     i18n: React.PropTypes.object
@@ -24,9 +26,8 @@ module.exports = React.createClass({
   getDefaultProps: function() {
     return {
       campaignUid: null,
-      campaignUids: null,
-      page_count: 1,
-      page_size: 12,
+      page: 1,
+      pageSize: 12,
       type: 'team',
       backgroundColor: null,
       textColor: null,
@@ -53,12 +54,7 @@ module.exports = React.createClass({
     this.setState({ isLoading: true });
 
     var props = this.props;
-
-    if (props.campaignUids) {
-      pages.findByCampaigns(props.campaignUids, props.type, props.page_size, props.page_count, this.onSuccess);
-    } else {
-      pages.findByCampaign(props.campaignUid, props.type, props.page_size, props.page_count, this.onSuccess);
-    }
+    pages.findByCampaign(props.campaignUid, props.type, props.pageSize, props.page, this.onSuccess);
   },
 
   onSuccess: function(result) {

--- a/src/components/teams/Teams/index.js
+++ b/src/components/teams/Teams/index.js
@@ -1,20 +1,21 @@
 "use strict";
 
-var _                 = require('lodash');
-var React             = require('react');
-var I18nMixin         = require('../../mixins/I18n');
-var pages             = require('../../../api/pages');
-var Icon              = require('../../helpers/Icon');
-var Team              = require('../Team');
+var _         = require('lodash');
+var React     = require('react');
+var I18nMixin = require('../../mixins/I18n');
+var pages     = require('../../../api/pages');
+var Icon      = require('../../helpers/Icon');
+var Team      = require('../Team');
 
 module.exports = React.createClass({
   mixins: [I18nMixin],
   displayName: "Teams",
   propTypes: {
     campaignUid: React.PropTypes.string,
+    campaignUids: React.PropTypes.array,
     type: React.PropTypes.string,
-    limit: React.PropTypes.string,
-    page: React.PropTypes.string,
+    page_count: React.PropTypes.number,
+    page_size: React.PropTypes.number,
     backgroundColor: React.PropTypes.string,
     textColor: React.PropTypes.string,
     i18n: React.PropTypes.object
@@ -22,9 +23,10 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
-      campaignUid: '',
-      page_count: '1',
-      page_size: '12',
+      campaignUid: null,
+      campaignUids: null,
+      page_count: 1,
+      page_size: 12,
       type: 'team',
       backgroundColor: null,
       textColor: null,
@@ -44,13 +46,19 @@ module.exports = React.createClass({
   },
 
   componentWillMount: function() {
-    this.setState({
-      isLoading: true
-    });
+    this.loadPages();
+  },
+
+  loadPages: function() {
+    this.setState({ isLoading: true });
 
     var props = this.props;
 
-    pages.findByCampaign(props.campaignUid, props.type, props.page_size, props.page_count, this.onSuccess);
+    if (props.campaignUids) {
+      pages.findByCampaigns(props.campaignUids, props.type, props.page_size, props.page_count, this.onSuccess);
+    } else {
+      pages.findByCampaign(props.campaignUid, props.type, props.page_size, props.page_count, this.onSuccess);
+    }
   },
 
   onSuccess: function(result) {
@@ -61,9 +69,7 @@ module.exports = React.createClass({
 
     function() {
       if (!_.isEmpty(this.state.pageResults)) {
-        this.setState({
-          hasResults: true
-        });
+        this.setState({ hasResults: true });
       }
     }.bind(this));
   },

--- a/src/docs.md
+++ b/src/docs.md
@@ -1106,11 +1106,8 @@ Displays a set of fundraiser profile images (that have a page) for a single spec
 }
 ```
 
-`campaignUid` (string)<br>
-Campaign uid to filter results by campaign.
-
-`campaignUids` (array)<br>
-Define multiple campaign uids to filter results by campaigns.
+`campaignUid` (string or array)<br>
+Campaign uid (or uids) to filter results by campaign.
 
 `backgroundColor` (string) <br>
 Accepts a CSS color value. Not set by default.
@@ -1529,13 +1526,10 @@ Displays a set of teams for a single specified campaign.
 }
 ```
 
-`campaignUid` (string)<br>
-Campaign uid to filter results by campaign.
+`campaignUid` ((string or array))<br>
+Campaign uid (or uids) to filter results by campaign.
 
-`campaignUids` (array)<br>
-Define multiple campaign uids to filter results by campaigns.
-
-`page_size` (number)<br>
+`pageSize` (number)<br>
 Set to `12` by default. Determines how many results are returned.
 
 `backgroundColor` (string)<br>

--- a/src/docs.md
+++ b/src/docs.md
@@ -1109,6 +1109,9 @@ Displays a set of fundraiser profile images (that have a page) for a single spec
 `campaignUid` (string or array)<br>
 Campaign uid (or uids) to filter results by campaign.
 
+`pageSize` (number)<br>
+Set to `6` by default. Determines how many results are returned.
+
 `backgroundColor` (string) <br>
 Accepts a CSS color value. Not set by default.
 

--- a/src/docs.md
+++ b/src/docs.md
@@ -1529,8 +1529,8 @@ Displays a set of teams for a single specified campaign.
 `campaignUid` (string) <span class="required">Required</span><br>
 Campaign uid to filter results by campaign.
 
-`page_size` (string)<br>
-Set to `'12'` by default. Determines how many results are returned.
+`page_size` (number)<br>
+Set to `12` by default. Determines how many results are returned.
 
 `backgroundColor` (string)<br>
 Accepts a CSS color value. Not set by default.

--- a/src/docs.md
+++ b/src/docs.md
@@ -1106,8 +1106,11 @@ Displays a set of fundraiser profile images (that have a page) for a single spec
 }
 ```
 
-`campaignUid` (string) <span class="required">Required</span> <br>
+`campaignUid` (string)<br>
 Campaign uid to filter results by campaign.
+
+`campaignUids` (array)<br>
+Define multiple campaign uids to filter results by campaigns.
 
 `backgroundColor` (string) <br>
 Accepts a CSS color value. Not set by default.
@@ -1526,8 +1529,11 @@ Displays a set of teams for a single specified campaign.
 }
 ```
 
-`campaignUid` (string) <span class="required">Required</span><br>
+`campaignUid` (string)<br>
 Campaign uid to filter results by campaign.
+
+`campaignUids` (array)<br>
+Define multiple campaign uids to filter results by campaigns.
 
 `page_size` (number)<br>
 Set to `12` by default. Determines how many results are returned.


### PR DESCRIPTION
- Added a method to handle pulling page results when passed multiple campaign uids
- Updated some props that were set to be strings by default, now set to type `number`. If the user still supplies a string it won't break, just gives a console warning.
- Updated docs.