### PR TITLE
Make individual leaderboard items link to supporter pages

### DIFF
--- a/src/components/leaderboards/LeaderboardItem/__tests__/LeaderboardItem-test.js
+++ b/src/components/leaderboards/LeaderboardItem/__tests__/LeaderboardItem-test.js
@@ -12,12 +12,18 @@ describe('LeaderboardItem', function() {
     var element;
 
     beforeEach(function() {
-      leaderboardItem = <LeaderboardItem campaignUid="au-0" />;
+      leaderboardItem = <LeaderboardItem url="hello-world.com" />;
       element = TestUtils.renderIntoDocument(leaderboardItem);
     });
 
     it('renders something', function() {
       expect(element).not.toBeNull();
+    });
+
+    it('is a link', function() {
+      var parentNode = element.getDOMNode();
+      expect(parentNode.tagName).toBe('A');
+      expect(parentNode.getAttribute('href')).toEqual('hello-world.com');
     });
 
     it('renders a profile image', function() {

--- a/src/components/leaderboards/LeaderboardItem/index.js
+++ b/src/components/leaderboards/LeaderboardItem/index.js
@@ -21,11 +21,11 @@ module.exports = React.createClass({
     };
 
     return (
-      <div className="LeaderboardItem" style={ style }>
+      <a href={ this.props.url } className="LeaderboardItem" style={ style }>
         <div className="LeaderboardItem__skin">
-          <a href={ this.props.url } className="LeaderboardItem__image">
+          <div className="LeaderboardItem__image">
             <img src={ this.props.imgSrc } />
-          </a>
+          </div>
           <div className="LeaderboardItem__content">
             <div className="LeaderboardItem__name">
               { this.props.name }
@@ -38,7 +38,7 @@ module.exports = React.createClass({
             { this.props.rank }
           </div>
         </div>
-      </div>
+      </a>
     );
   }
 });

--- a/src/components/leaderboards/LeaderboardItem/style.scss
+++ b/src/components/leaderboards/LeaderboardItem/style.scss
@@ -4,6 +4,7 @@
   padding: $x-1;
   float: left;
   position: relative;
+  text-decoration: none;
 
   @include media-max($breakpoint-xl) {
     width: 50%;


### PR DESCRIPTION
Makes the whole leaderboard item clickable (rather than just the small profile image).