### PR TITLE
Add imageless option

### DIFF
--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -28,6 +28,7 @@ module.exports = React.createClass({
     textColor: React.PropTypes.string,
     childWidth: React.PropTypes.number,
     currencyFormat: React.PropTypes.string,
+    renderImage: React.PropTypes.bool,
     i18n: React.PropTypes.object,
     onHasContent: React.PropTypes.func
   },
@@ -39,6 +40,7 @@ module.exports = React.createClass({
       backgroundColor: null,
       textColor: null,
       childWidth: 250,
+      renderImage: true,
       currencyFormat: '0,0[.]00',
       defaultI18n: {
         symbol: '$',
@@ -52,7 +54,7 @@ module.exports = React.createClass({
       isLoading: false,
       boardData: [],
       currentPage: 1,
-      childWidth: this.props.childWidth,
+      childWidth: this.props.childWidth
     };
   },
 
@@ -83,9 +85,7 @@ module.exports = React.createClass({
     var currentPage = this.state.currentPage - 1;
     var board = this.state.boardData[currentPage];
 
-    if (!board) {
-      return;
-    }
+    if (!board) return;
 
     return board.map(function(d,i) {
       var formattedAmount = this.formatAmount(d.amount);
@@ -100,9 +100,9 @@ module.exports = React.createClass({
           isoCode={ d.isoCode }
           amount={ formattedAmount }
           imgSrc={ d.medImgSrc }
-          width={ this.state.childWidth } />
+          width={ this.state.childWidth }
+          renderImage={ this.props.renderImage } />
       );
-
     }, this);
   },
 

--- a/src/components/leaderboards/LeaderboardItem/__tests__/LeaderboardItem-test.js
+++ b/src/components/leaderboards/LeaderboardItem/__tests__/LeaderboardItem-test.js
@@ -6,6 +6,7 @@ describe('LeaderboardItem', function() {
   var LeaderboardItem = require('../');
   var TestUtils       = React.addons.TestUtils;
   var findByClass     = TestUtils.findRenderedDOMComponentWithClass;
+  var scryByClass     = TestUtils.scryRenderedDOMComponentsWithClass;
 
   describe('Component defaults', function() {
     var leaderboardItem;
@@ -26,11 +27,6 @@ describe('LeaderboardItem', function() {
       expect(parentNode.getAttribute('href')).toEqual('hello-world.com');
     });
 
-    it('renders a profile image', function() {
-      var elementImg = findByClass(element, 'LeaderboardItem__image');
-      expect(elementImg).not.toBeNull();
-    });
-
     it('renders funds raised', function() {
       var elementFunds = findByClass(element, 'LeaderboardItem__amount');
       expect(elementFunds).not.toBeNull();
@@ -44,6 +40,26 @@ describe('LeaderboardItem', function() {
     it('renders a rank', function() {
       var elementRank = findByClass(element, 'LeaderboardItem__rank');
       expect(elementRank).not.toBeNull();
+    });
+  });
+
+  describe('Render image option', function() {
+    var leaderboardItem;
+    var element;
+    var elementImg;
+
+    it('renders a profile image if set to true', function() {
+      leaderboardItem = <LeaderboardItem renderImage={ true } />;
+      element = TestUtils.renderIntoDocument(leaderboardItem);
+      elementImg = scryByClass(element, 'LeaderboardItem__image');
+      expect(elementImg.length).toEqual(1);
+    });
+
+    it('renders wont render an image if set to false', function() {
+      leaderboardItem = <LeaderboardItem renderImage={ false } />;
+      element = TestUtils.renderIntoDocument(leaderboardItem);
+      elementImg = scryByClass(element, 'LeaderboardItem__image');
+      expect(elementImg.length).toEqual(0);
     });
   });
 });

--- a/src/components/leaderboards/LeaderboardItem/index.js
+++ b/src/components/leaderboards/LeaderboardItem/index.js
@@ -12,20 +12,27 @@ module.exports = React.createClass({
     name: React.PropTypes.string.isRequired,
     isoCode: React.PropTypes.string.isRequired,
     amount: React.PropTypes.string.isRequired,
-    width: React.PropTypes.string.isRequired
+    width: React.PropTypes.string.isRequired,
+    renderImage: React.PropTypes.bool.isRequired
+  },
+
+  renderProfileImage: function() {
+    if (this.props.renderImage) {
+      return (
+        <div className="LeaderboardItem__image">
+          <img src={ this.props.imgSrc } />
+        </div>
+      );
+    }
   },
 
   render: function() {
-    var style = {
-      width: this.props.width
-    };
+    var style = { width: this.props.width };
 
     return (
       <a href={ this.props.url } className="LeaderboardItem" style={ style }>
         <div className="LeaderboardItem__skin">
-          <div className="LeaderboardItem__image">
-            <img src={ this.props.imgSrc } />
-          </div>
+          { this.renderProfileImage() }
           <div className="LeaderboardItem__content">
             <div className="LeaderboardItem__name">
               { this.props.name }

--- a/src/components/leaderboards/LeaderboardItem/style.scss
+++ b/src/components/leaderboards/LeaderboardItem/style.scss
@@ -27,7 +27,7 @@
 .LeaderboardItem__content {
   box-sizing: border-box;
   width: 100%;
-  padding: $x-4 $x-16;
+  padding: $x-4;
 
   .LeaderboardItem__name {
     box-sizing: border-box;
@@ -62,5 +62,9 @@
     max-width: 100%;
     border-radius: 50%;
     border: 0;
+  }
+
+  & + .LeaderboardItem__content {
+    padding: $x-4 $x-16;
   }
 }

--- a/src/components/leaderboards/TeamLeaderboard/index.js
+++ b/src/components/leaderboards/TeamLeaderboard/index.js
@@ -29,6 +29,8 @@ module.exports = React.createClass({
     childWidth: React.PropTypes.number,
     currencyFormat: React.PropTypes.string,
     i18n: React.PropTypes.object,
+    altTemplate: React.PropTypes.bool,
+    renderImage: React.PropTypes.bool,
     onHasContent: React.PropTypes.func
   },
 
@@ -40,6 +42,7 @@ module.exports = React.createClass({
       textColor: null,
       childWidth: 250,
       altTemplate: false,
+      renderImage: true,
       currencyFormat: '0[.]00 a',
       defaultI18n: {
         raisedTitle: 'Raised',

--- a/src/docs.md
+++ b/src/docs.md
@@ -881,6 +881,9 @@ Accepts a CSS color value. Not set by default.
 `childWidth` (number)<br>
 Set to `250` by default. Sets the minimum width for leaderboard items to display.
 
+`renderImage` (boolean)<br>
+Set to `true` by default. Determines whether a profile image is rendered for each leaderboard item.
+
 `currencyFormat` (string)<br>
 Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).
 
@@ -961,6 +964,9 @@ Set to `250` by default. Sets the minimum width for leaderboard items to display
 
 `altTemplate` (boolean)<br>
 Set to `false` by default. Renders an alternate template set when set to `true`.
+
+`renderImage` (boolean)<br>
+Set to `true` by default. Determines whether a profile image is rendered for each leaderboard item.
 
 `currencyFormat` (string)<br>
 Set to `'0[.]00 a'` by default. [More format strings](http://numeraljs.com/).


### PR DESCRIPTION
Adds a `renderImage` option to both team and individual leaderboards. Setting to false will stop the supporter page profile image from rendering. Here's what it looks like with no image:

![screen shot 2015-07-17 at 3 39 54 pm](https://cloud.githubusercontent.com/assets/859298/8741302/f1597a4c-2c99-11e5-8a1d-615e69a55b46.png)
