### PR TITLE
Fixes warning on missing campaginUrl

### DIFF
--- a/src/components/events/Event/index.js
+++ b/src/components/events/Event/index.js
@@ -14,7 +14,7 @@ module.exports = React.createClass({
   propTypes: {
     name: React.PropTypes.string.isRequired,
     date: React.PropTypes.object.isRequired,
-    campaignUrl: React.PropTypes.string.isRequired,
+    campaignUrl: React.PropTypes.string,
     donateUrl: React.PropTypes.string,
     getStartedUrl: React.PropTypes.string,
     backgroundImageUrl: React.PropTypes.string,


### PR DESCRIPTION
Many production campaigns do not have a url specified, so this warning is incorrect.