### PR TITLE
Fix charity widget

### DIFF
--- a/src/components/charities/PromoCharities/index.js
+++ b/src/components/charities/PromoCharities/index.js
@@ -72,21 +72,9 @@ module.exports = React.createClass({
   },
 
   orderCharities: function(charities, keys) {
-    var tempObj = {};
-
-    _.forEach(charities, function(charity) {
-      tempObj[charity.id] = charity;
+    return _.sortBy(charities, function(charity) {
+      return keys.indexOf(charity.id);
     });
-
-    _.forEach(keys, function(key, i) {
-      if (charities[i]) {
-        charities[i] = tempObj[key];
-      }
-    });
-
-    console.log(charities);
-
-    return charities;
   },
 
   fetchUrl: function(charity) {

--- a/src/components/charities/PromoCharities/index.js
+++ b/src/components/charities/PromoCharities/index.js
@@ -79,8 +79,12 @@ module.exports = React.createClass({
     });
 
     _.forEach(keys, function(key, i) {
-      charities[i] = tempObj[key];
+      if (charities[i]) {
+        charities[i] = tempObj[key];
+      }
     });
+
+    console.log(charities);
 
     return charities;
   },


### PR DESCRIPTION
The Promoted Charities widget was returning an error if you handed it a charity id that didn't exist in our API - This caused the widget to fall over and show infinite loading. 

It was being caused by this janky sort method that was creating a new key inside the `charities` array and passing undefined content down to children. Now it just fails gracefully by omitting the rogue id and rendering the rest.

Hooray lodash.