### PR TITLE
Fix search: page types

### DIFF
--- a/src/api/__tests__/pages-test.js
+++ b/src/api/__tests__/pages-test.js
@@ -72,7 +72,7 @@ describe('pages', function() {
 
   describe('search', function() {
     it('searches for pages', function() {
-      var query = { searchTerm: 'bar', country: 'xy', campaignUid: ['xy-12', 'xy-42'], charityUid: 'xy-123', type: 'foo', page: 2, pageSize: 7 };
+      var query = { searchTerm: 'bar', country: 'xy', campaignUid: ['xy-12', 'xy-42'], charityUid: 'xy-123', pageType: 'foo', page: 2, pageSize: 7 };
       var callback = jest.genMockFunction();
       pages.search(query, callback);
 

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -21,7 +21,7 @@ var baseRoutes = {
   searchAggregate:      '{baseUrl}/api/v2/search/aggregate.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
   searchCampaigns:      '{baseUrl}/api/v2/search/campaigns.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
   searchCharities:      '{baseUrl}/api/v2/search/charities.jsonp?q={searchTerm}&country_code={country}&campaign_id={campaignUid}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
-  searchPages:          '{baseUrl}/api/v2/search/pages.jsonp?q={searchTerm}&country_code={country}&campaign_id={campaignUid}&charity_id={charityUid}&type={type}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
+  searchPages:          '{baseUrl}/api/v2/search/pages.jsonp?q={searchTerm}&country_code={country}&campaign_id={campaignUid}&charity_id={charityUid}&type={pageType}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
 
   address:              '{baseUrl}/api/v2/addresses/{country}/{id}.jsonp',
   searchAddresses:      '{baseUrl}/api/v2/addresses.jsonp?country_code={country}&q={searchTerm}',


### PR DESCRIPTION
Page search  in routes was looking for the wrong param name and thus setting a `pageType` in search widgets was doing nothing.