### PR TITLE
Add watchify, remove watch-dev script in favour of watch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ OSX users may need to increase the maximum number of open files (default is 256)
 $ npm run setup         # install global dependencies, node modules and build production assets
 $ npm run build         # build production assets
 $ npm run build-dev     # build un minified assets (for debugging)
-$ npm run watch         # watch assets and build production
-$ npm run watch-dev     # watch assets and build un minified assets (for debugging)
+$ npm run watch         # watch assets and build production (un-minified)
 $ npm run jshint        # check javascript code quality
 $ npm run scripts       # build production scripts
 $ npm run scripts-dev   # build un-minified scripts (for debugging)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "superagent": "~0.21.0",
     "vinyl-buffer": "~1.0.0",
     "vinyl-source-stream": "~1.0.0",
+    "watchify": "^3.4.0",
     "wget": "~0.0.1"
   },
   "repository": {
@@ -80,8 +81,7 @@
     "setup": "npm install && npm run build && npm test",
     "build": "gulp",
     "build-dev": "NODE_ENV=development gulp --debug",
-    "watch": "npm run build && gulp watch",
-    "watch-dev": "npm run build-dev && gulp watch --debug",
+    "watch": "npm run build-dev && gulp watch --debug",
     "jshint": "gulp jshint",
     "scripts": "gulp scripts",
     "scripts-dev": "gulp scripts --debug",


### PR DESCRIPTION
Added [watchify](https://github.com/substack/watchify) to reduce build time when running a watch script. Also simplified by renaming the `watch-dev` script (now `watch` does the same thing) since 100% of the time if you are running watch you don't want to waste build time on minification.

Without watchify:

<img width="467" alt="screen shot 2015-09-09 at 6 23 02 pm" src="https://cloud.githubusercontent.com/assets/859298/9756795/1272cf98-5720-11e5-94f6-cdb0cc417ac7.png">

With watchify:

<img width="658" alt="screen shot 2015-09-09 at 6 21 53 pm" src="https://cloud.githubusercontent.com/assets/859298/9756806/21ea3d08-5720-11e5-80dd-64c53f640d81.png">