### PR TITLE
Add Custom search widget

### DIFF
--- a/src/api/frolCharities.js
+++ b/src/api/frolCharities.js
@@ -1,0 +1,67 @@
+"use strict";
+
+var getJSONP     = require('../lib/getJSONP');
+var _            = require('lodash');
+var cachedResult;
+
+var url = 'https://spreadsheets.google.com/feeds/list/1FnIPOD3M1lQXFkERRl_tdGz5XXZ3AmNdBCaLPpcClFI/od6/public/values?alt=json-in-script';
+
+function getCharities(callback) {
+  if (cachedResult) {
+    setTimeout(function() {
+      callback(cachedResult);
+    });
+
+    return;
+  }
+
+  getJSONP(url, function(data) {
+    var transformedData = [];
+    var entries = data.feed.entry;
+
+    for (var i = 0; i < entries.length; i++) {
+      transformedData.push({
+        name: entries[i].gsx$name.$t,
+        frolId: entries[i].gsx$frolid.$t,
+        slug: entries[i].gsx$slug.$t,
+        description: entries[i].gsx$description.$t,
+        logoUrl: entries[i].gsx$logourl.$t,
+        url: entries[i].gsx$url.$t
+      });
+    }
+
+    cachedResult = transformedData;
+    callback(transformedData);
+  });
+}
+
+function search(properties, callback) {
+  getCharities(function(charities) {
+    var results = properties.searchTerm === '' ? charities : _.filter(charities, function(charity){
+      return charity.name.search(new RegExp(properties.searchTerm, 'gim')) >= 0;
+    });
+
+    var count = results.length;
+    var totalPages = count / properties.pageSize;
+    var endIndex = (properties.page * properties.pageSize);
+    var beginIndex =  endIndex - properties.pageSize;
+    var meta = {
+      pagination: {
+        current_page: properties.page,
+        count: count,
+        total_pages: Math.ceil(results.length / properties.pageSize),
+        first_page: properties.page === 1,
+        last_page: properties.page === totalPages && count !== 0
+      }
+    };
+
+    callback({
+      charities: results.slice(beginIndex, endIndex),
+      meta: meta
+    });
+  });
+}
+
+module.exports = {
+  search: search
+};

--- a/src/components/helpers/Overlay/index.js
+++ b/src/components/helpers/Overlay/index.js
@@ -27,7 +27,7 @@ module.exports = React.createClass({
   getInitialState: function() {
     return {
       scrollPosition: 0
-    }
+    };
   },
 
   keyHandler: function(event) {

--- a/src/components/search/CharitySearchModalCustom/__tests__/CharitySearchModal-test.js
+++ b/src/components/search/CharitySearchModalCustom/__tests__/CharitySearchModal-test.js
@@ -1,0 +1,128 @@
+"use strict";
+jest.autoMockOff();
+
+jest.mock('../../../../api/frolCharities');
+var charities = require('../../../../api/frolCharities');
+var searchResponse = {};
+
+charities.search.mockReturnValue(searchResponse);
+
+var _ = require('lodash');
+_.debounce = function(callback) { return callback; };
+
+var React              = require('react/addons');
+var TestUtils          = React.addons.TestUtils;
+var CharitySearchModal = require('../');
+var SearchModal        = require('../../SearchModal');
+var findByClass        = TestUtils.findRenderedDOMComponentWithClass;
+var findByType         = TestUtils.findRenderedComponentWithType;
+var scryByClass        = TestUtils.scryRenderedDOMComponentsWithClass;
+var findByTag          = TestUtils.findRenderedDOMComponentWithTag;
+
+var charity = {
+  uid: 'xy-12',
+  slug: 'foo',
+  name: 'Foo',
+  description: 'Fooy',
+  country_code: 'xy',
+  url: 'http://foo.com/'
+};
+
+var charity2 = {
+  uid: 'xy-42',
+  slug: 'bar',
+  name: 'Bar',
+  description: 'Bary',
+  country_code: 'xy',
+  url: 'http://bar.com/'
+};
+
+var searchResponse = {
+  charities: [charity],
+  meta: {
+    pagination: {
+      count: 1,
+      current_page: 1,
+      total_pages: 2
+    }
+  }
+};
+
+
+describe('CharitySearchModal', function() {
+  beforeEach(function() {
+    charities.search.mockClear();
+  });
+
+  it('renders a SearchModal', function() {
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } />;
+    var element = TestUtils.renderIntoDocument(charitySearchModal);
+    var searchModal = findByType(element, SearchModal);
+
+    expect(searchModal).toBeDefined();
+  });
+
+  it('renders search results', function() {
+    charities.search.mockImplementation(function(query, callback) { callback(searchResponse); });
+
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } />;
+    var element = TestUtils.renderIntoDocument(charitySearchModal);
+    var resultElements = scryByClass(element, 'SearchResult');
+
+    expect(resultElements.length).toEqual(1);
+    expect(resultElements[0].getDOMNode().textContent).toContain(charity.name);
+    expect(resultElements[0].getDOMNode().textContent).toContain(charity.description);
+  });
+
+  it('searches for charities on input change', function() {
+    var query = { searchTerm: 'foo', page: 1, pageSize: 10 };
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } country="xy" />;
+    var element = TestUtils.renderIntoDocument(charitySearchModal);
+    var input = findByTag(element, 'input');
+    TestUtils.Simulate.change(input, { target: { value: 'foo' } });
+
+    expect(charities.search.mock.calls.length).toEqual(2);
+    expect(charities.search).lastCalledWith(query, element.updateResults);
+  });
+
+  it('searches for more charities on page change', function() {
+    charities.search.mockImplementation(function(query, callback) { callback(searchResponse); });
+
+    var query = { searchTerm: '', page: 2, pageSize: 10 };
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } country="xy" />;
+    var element = TestUtils.renderIntoDocument(charitySearchModal);
+    var nextPageButton = findByClass(element, 'SearchPagination__button--right');
+    TestUtils.Simulate.click(nextPageButton);
+
+    expect(charities.search.mock.calls.length).toEqual(2);
+    expect(charities.search).lastCalledWith(query, element.updateResults);
+  });
+
+  it('updates isSearching accordingly', function() {
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } country="xy" />;
+    var element = TestUtils.renderIntoDocument(charitySearchModal);
+
+    expect(element.state.isSearching).toBeTruthy();
+
+    var searchCallback = charities.search.mock.calls[0][1];
+    searchCallback(searchResponse);
+
+    expect(element.state.isSearching).toBeFalsy();
+
+    var input = findByTag(element, 'input');
+    TestUtils.Simulate.change(input, { target: { value: 'foo' } });
+
+    expect(element.state.isSearching).toBeTruthy();
+  });
+
+  it('links to charity url for default visit action', function() {
+    var onClose = jest.genMockFunction();
+    var charitySearchModal = <CharitySearchModal autoFocus={ false } onClose={ onClose } />;
+    var element = TestUtils.renderIntoDocument(charitySearchModal);
+    element.setState({ results: [charity] });
+
+    var resultElements = scryByClass(element, 'SearchResult');
+
+    expect(resultElements[0].getDOMNode().href).toBe(charity.url);
+  });
+});

--- a/src/components/search/CharitySearchModalCustom/index.js
+++ b/src/components/search/CharitySearchModalCustom/index.js
@@ -1,0 +1,142 @@
+"use strict";
+
+var _                   = require('lodash');
+var React               = require('react');
+var SearchModal         = require('../SearchModal');
+var CharitySearchResult = require('../CharitySearchResult');
+var I18nMixin           = require('../../mixins/I18n');
+var apis = {
+  frol: require('../../../api/frolCharities')
+};
+
+module.exports = React.createClass({
+  displayName: 'CharitySearchModalFROL',
+
+  mixins: [I18nMixin],
+
+  propTypes: {
+    action: React.PropTypes.oneOf(['visit', 'donate', 'fundraise', 'custom']),
+    autoFocus: React.PropTypes.bool,
+    i18n: React.PropTypes.object,
+    onClose: React.PropTypes.func.isRequired,
+    api: React.PropTypes.oneOf(['frol'])
+  },
+
+  getDefaultProps: function() {
+    return {
+      action: 'visit',
+      autoFocus: true,
+      campaignUid: '',
+      campaignSlug: null,
+      defaultI18n: {
+        title: 'Search for a Charity',
+        visitAction: 'Visit Charity',
+        donateAction: 'Give to this Charity',
+        fundraiseAction: 'Fundraise for this Charity',
+        emptyLabel: "We couldn't find any matching Charities."
+      },
+      pageSize: 10,
+      api: 'frol'
+    };
+  },
+
+  getInitialState: function() {
+    return {
+      cancelRequest: null,
+      results: null,
+      isSearching: false,
+      pagination: {
+        count: 0,
+        page: 1,
+        pageSize: 1,
+        totalPages: 0,
+      }
+    };
+  },
+
+  componentDidMount: function() {
+    this.search('', 1);
+  },
+
+  pageChanged: function(page) {
+    this.search(this.state.searchTerm, page);
+  },
+
+  inputChanged: function(searchTerm) {
+    this.search(searchTerm, 1);
+  },
+
+  search: function(searchTerm, page) {
+    if (this.state.cancelRequest) {
+      this.state.cancelRequest();
+    }
+
+    var cancelRequest = apis[this.props.api].search({
+      searchTerm: searchTerm,
+      page: page || 1,
+      pageSize: this.props.pageSize
+    }, this.updateResults);
+
+    this.setState({
+      searchTerm: searchTerm,
+      isSearching: true,
+      cancelRequest: cancelRequest
+    });
+  },
+
+  updateResults: function(results) {
+    if (results) {
+      this.setState({
+        cancelRequest: null,
+        results: results.charities,
+        isSearching: false,
+        pagination: {
+          count: results.meta.pagination.count,
+          page: results.meta.pagination.current_page,
+          pageSize: this.props.pageSize,
+          totalPages: results.meta.pagination.total_pages
+        }
+      });
+    } else {
+      this.setState(this.getInitialState());
+    }
+  },
+
+  selectHandler: function(result) {
+    window.location = result.charity.url;
+  },
+
+  selectAction: function() {
+    return this.t(this.props.action + 'Action');
+  },
+
+  getResults: function() {
+    var props = this.props;
+    var results = this.state.results;
+
+    return results && results.map(function(charity) {
+      return {
+        id: charity.id,
+        charity: charity,
+        url: charity.url
+      };
+    });
+  },
+
+  render: function() {
+    return (
+      <SearchModal
+        autoFocus={ this.props.autoFocus }
+        i18n={ this.getI18n() }
+        isSearching={ this.state.isSearching }
+        onClose={ this.props.onClose }
+        onInputChange={ this.inputChanged }
+        onPageChange={ this.pageChanged }
+        onSelect={ this.selectHandler }
+        pagination={ this.state.pagination }
+        results={ this.getResults() }
+        resultComponent={ CharitySearchResult }
+        selectAction={ this.selectAction() } />
+    );
+  }
+});

--- a/src/index.html
+++ b/src/index.html
@@ -153,6 +153,7 @@
         <a id="CharitySearchVisit" class="modal"><i class="Icon fa fa-heart fa-fw"></i> Find a Charity</a>
         <a id="CharitySearchDonate" class="modal"><i class="Icon fa fa-money fa-fw"></i> Donate to a Charity</a>
         <a id="CharitySearchFundraise" class="modal"><i class="Icon fa fa-bolt fa-fw"></i> Fundraise for a Charity</a>
+        <a id="CharitySearchFundraiseFROL" class="modal"><i class="Icon fa fa-bolt fa-fw"></i> Fundraise for a FROL</a>
         <a id="PageSearchExample" class="modal"><i class="Icon fa fa-group fa-fw"></i> Support a Friend</a>
         <a id="AggregateSearchExample" class="modal"><i class="Icon fa fa-asterisk fa-fw"></i> Aggregate Search</a>
         <div id="SearchInput">Search Input</div>
@@ -226,6 +227,7 @@
     edh.widgets.initModal('CharitySearchVisit', 'CharitySearch', { country: 'uk' });
     edh.widgets.initModal('CharitySearchDonate', 'CharitySearch', { country: 'uk', action: 'donate' });
     edh.widgets.initModal('CharitySearchFundraise', 'CharitySearch', { country: 'uk', action: 'fundraise' });
+    edh.widgets.initModal('CharitySearchFundraiseFROL', 'CharitySearchModalCustom', { action: 'fundraise' });
     edh.widgets.initModal('PageSearchExample', 'PageSearch', { country: 'uk' });
     edh.widgets.initModal('AggregateSearchExample', 'AggregateSearch', { country: 'uk' });
     edh.widgets.renderWidget('SearchInput', 'SearchInput', {

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -44,6 +44,7 @@ var widgets = {
 var modals = {
   AggregateSearch: require('./components/search/AggregateSearchModal'),
   CharitySearch: require('./components/search/CharitySearchModal'),
+  CharitySearchModalCustom: require('./components/search/CharitySearchModalCustom'),
   PageSearch: require('./components/search/PageSearchModal'),
 };
 


### PR DESCRIPTION
Add Custom search widget to allow searching of alternate API's – to support search of fundraiseOnline charities.

Don't look to hard, this is a copy of the existing search component with a few changes.

![screen shot 2015-10-08 at 5 20 37 pm](https://cloud.githubusercontent.com/assets/3256309/10360039/fbe1982c-6de0-11e5-90ea-31b2c0b91027.png)
