### PR TITLE
[TA-7343] Expose new aggregate search options

### DIFF
--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -19,11 +19,7 @@ var baseRoutes = {
   pages:                '{baseUrl}/api/v2/pages.jsonp?ids={pageIds}&campaign_id={campaignUid}&charity_ids={charityUid}&type={type}&include_footprint={includeFootprint}&page={page}&limit={limit}&start_created_at={start}&end_created_at={end}',
 
   searchAggregate:      '{baseUrl}/api/v2/search/aggregate.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
-
-
   searchCampaigns:      '{baseUrl}/api/v2/search/campaigns.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}&charity_ids={charityUids}',
-
-
   searchCharities:      '{baseUrl}/api/v2/search/charities.jsonp?q={searchTerm}&country_code={country}&campaign_id={campaignUid}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
   searchPages:          '{baseUrl}/api/v2/search/pages.jsonp?q={searchTerm}&country_code={country}&campaign_id={campaignUid}&charity_id={charityUid}&type={pageType}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
 

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -19,7 +19,11 @@ var baseRoutes = {
   pages:                '{baseUrl}/api/v2/pages.jsonp?ids={pageIds}&campaign_id={campaignUid}&charity_ids={charityUid}&type={type}&include_footprint={includeFootprint}&page={page}&limit={limit}&start_created_at={start}&end_created_at={end}',
 
   searchAggregate:      '{baseUrl}/api/v2/search/aggregate.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
-  searchCampaigns:      '{baseUrl}/api/v2/search/campaigns.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
+
+
+  searchCampaigns:      '{baseUrl}/api/v2/search/campaigns.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}&charity_ids={charityUids}',
+
+
   searchCharities:      '{baseUrl}/api/v2/search/charities.jsonp?q={searchTerm}&country_code={country}&campaign_id={campaignUid}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
   searchPages:          '{baseUrl}/api/v2/search/pages.jsonp?q={searchTerm}&country_code={country}&campaign_id={campaignUid}&charity_id={charityUid}&type={pageType}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
 

--- a/src/components/search/AggregateSearchModal/__tests__/AggregateSearchModal-test.js
+++ b/src/components/search/AggregateSearchModal/__tests__/AggregateSearchModal-test.js
@@ -1,0 +1,52 @@
+"use strict";
+
+jest.autoMockOff();
+
+var React                = require('react/addons');
+var TestUtils            = React.addons.TestUtils;
+var AggregateSearchModal = require('../');
+var findByClass          = TestUtils.findRenderedDOMComponentWithClass;
+var scryByClass          = TestUtils.scryRenderedDOMComponentsWithClass;
+var searchModal;
+var element;
+
+describe('AggregateSearchModal', function() {
+  beforeEach(function() {
+    searchModal = <AggregateSearchModal autoFocus={ false } />;
+    element     = TestUtils.renderIntoDocument(searchModal);
+  });
+
+  it('renders a modal overlay', function() {
+    var overlayElement = findByClass(element, 'Overlay');
+    expect(overlayElement).toBeDefined();
+  });
+
+  it('renders a loading state while fetching results', function() {
+    element.setState({ isSearching: true, results: true });
+    findByClass(element, 'AggregateSearchModal__footer--loading');
+  });
+
+  it('renders an empty state if no results can be found', function() {
+    element.setState({ isSearching: false, results: {} });
+    findByClass(element, 'AggregateSearchModal__footer--empty');
+  });
+
+  it('renders all filters by default', function() {
+    element.setState({ results: { foo: 'bar' }, isSearching: false });
+    expect(scryByClass(element, 'AggregateSearchModal__filters__type').length).toBe(3);
+  });
+});
+
+describe('AggregateSearchModal with searchType prop set', function() {
+  it('renders a single filter based on the `searchType` prop', function() {
+    searchModal = <AggregateSearchModal autoFocus={ false } searchType="campaigns" />;
+    element     = TestUtils.renderIntoDocument(searchModal);
+
+    element.setState({ results: { foo: 'bar' }, isSearching: false });
+
+    var filterElements = scryByClass(element, 'AggregateSearchModal__filters__type');
+
+    expect(filterElements.length).toBe(1);
+    expect(filterElements[0].getDOMNode().textContent).toContain('Events');
+  });
+});

--- a/src/components/search/AggregateSearchResult/__tests__/AggregateSearchResult-test.js
+++ b/src/components/search/AggregateSearchResult/__tests__/AggregateSearchResult-test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+jest.autoMockOff();
+
+var React       = require('react/addons');
+var Result      = require('../');
+var TestUtils   = React.addons.TestUtils;
+var findByClass = TestUtils.findRenderedDOMComponentWithClass;
+
+describe('AggregateSearchResult', function() {
+  var result = { id: '123', name: 'Enraged Potato' };
+  var url    = 'http://potato.com/';
+
+  it('renders result with content', function() {
+    var searchResult = <Result url={ url } result={ result }>foo</Result>;
+    var component = TestUtils.renderIntoDocument(searchResult);
+    var element = findByClass(component, 'AggregateSearchResult');
+
+    expect(element.getDOMNode().textContent).toBe('foo');
+  });
+
+  it('links to given url if onSelect callback not given', function() {
+    var searchResult = <Result result={ result } url={ url } />;
+    var component    = TestUtils.renderIntoDocument(searchResult);
+    var element      = findByClass(component, 'AggregateSearchResult');
+
+    expect(element.getDOMNode().href).toBe(url);
+  });
+
+  it('calls onSelect on click if given', function() {
+    var callback     = jest.genMockFunction();
+    var searchResult = <Result result={ result } onSelect={ callback } />;
+    var component    = TestUtils.renderIntoDocument(searchResult);
+    var element      = findByClass(component, 'AggregateSearchResult');
+
+    TestUtils.Simulate.click(element);
+
+    expect(callback).toBeCalledWith(result);
+  });
+});

--- a/src/components/search/AggregateSearchResult/index.js
+++ b/src/components/search/AggregateSearchResult/index.js
@@ -7,17 +7,24 @@ module.exports = React.createClass({
 
   propTypes: {
     url: React.PropTypes.string,
+    result: React.PropTypes.object,
     onSelect: React.PropTypes.func
   },
 
+  handleClick: function(e) {
+    e.preventDefault();
+    this.props.onSelect(this.props.result);
+  },
+
   render: function() {
-    var props = this.props;
+    var props       = this.props;
+    var handleClick = props.onSelect && this.handleClick;
 
     return (
       <a href={ props.url || '#' }
         className="AggregateSearchResult"
-        onClick={ props.onSelect }>
-        { props.children }
+        onClick={ handleClick }>
+        { this.props.children }
       </a>
     );
   }

--- a/src/components/search/AggregateSearchResult/style.scss
+++ b/src/components/search/AggregateSearchResult/style.scss
@@ -1,6 +1,7 @@
 .AggregateSearchResult {
   @extend %clearfix;
   display: block;
+  cursor: pointer;
   color: $ehw-grey;
   line-height: 1;
   font-size: 12px;

--- a/src/components/search/AggregateSearchResultCampaign/index.js
+++ b/src/components/search/AggregateSearchResultCampaign/index.js
@@ -71,7 +71,7 @@ module.exports = React.createClass({
     var url = campaign.url || campaign.get_started_url;
 
     return (
-      <AggregateSearchResult url={ url } onSelect={ this.props.onSelect }>
+      <AggregateSearchResult url={ url } onSelect={ this.props.onSelect } result={ campaign }>
         { this.renderDate() }
         <div className='AggregateSearchResultCampaign__content'>
           <div className='AggregateSearchResultCampaign__header'>{ campaign.name }</div>

--- a/src/components/search/AggregateSearchResultCharity/index.js
+++ b/src/components/search/AggregateSearchResultCharity/index.js
@@ -56,7 +56,7 @@ module.exports = React.createClass({
     var charity = this.props.result;
 
     return (
-      <AggregateSearchResult url={ charity.url } onSelect={ this.props.onSelect }>
+      <AggregateSearchResult url={ charity.url } result={ charity } onSelect={ this.props.onSelect }>
         { this.renderLogo() || this.renderAvatar() }
         <div className='AggregateSearchResultCharity__content'>
           <div className='AggregateSearchResultCharity__header'>{ charity.name }</div>

--- a/src/components/search/AggregateSearchResultPage/index.js
+++ b/src/components/search/AggregateSearchResultPage/index.js
@@ -66,7 +66,7 @@ module.exports = React.createClass({
     var page = this.props.result;
 
     return (
-      <AggregateSearchResult url={ page.url } onSelect={ this.props.onSelect }>
+      <AggregateSearchResult url={ page.url } onSelect={ this.props.onSelect } result={ page }>
         <div className='AggregateSearchResultPage__avatar'>
           <img src={ page.image.medium_image_url } />
         </div>

--- a/src/docs.md
+++ b/src/docs.md
@@ -158,6 +158,16 @@ Country code of region, either 'au', 'ie', 'nz', 'uk' or 'us'.
 `i18n` (object)<br>
 Object containing localised text.
 
+`searchType` (string)<br>
+Optional string used to constrain search results to a given type. Set to either 'campaigns', 'charities', 'pages', or 'all'. Default is set to 'all'.
+
+`charityUids` (array)<br>
+Optional array used to filter campaign results by given charity uids.
+
+`onSelect` (function)<br>
+Optional function called on selecting a result. Takes a single argument that returns a full API response object for the selected result.
+
+
 ## CharitySearch
 
 > The button element acts as a trigger to open the CharitySearch widget.


### PR DESCRIPTION
Added the ability to constrain aggregate search component so it returns results of a specific type – basically making it "non-aggregate-y", but meaning we can replace the other search widgets with just this one.

The primary use case atm is that we need a campaign search in NFP and thought it better to do this than create yet another search widget.

Also passed the custom `onSelect` callback down to the "result" components so you can now override the default onClick behaviour. `onSelect` was already there but the prop wasn't being handed down to children.

Oh and tests, a couple of them exist now :smiley: 