### PR TITLE
[TA-7343] Improve aggregate search

### DIFF
--- a/src/components/search/AggregateSearchModal/__tests__/AggregateSearchModal-test.js
+++ b/src/components/search/AggregateSearchModal/__tests__/AggregateSearchModal-test.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 jest.autoMockOff();
 
@@ -35,18 +35,36 @@ describe('AggregateSearchModal', function() {
     element.setState({ results: { foo: 'bar' }, isSearching: false });
     expect(scryByClass(element, 'AggregateSearchModal__filters__type').length).toBe(3);
   });
+
+  it('selects a filter when a filter selection button is clicked', function() {
+    element.setState({ results: { foo: 'bar' }, isSearching: false });
+    var filterElements = scryByClass(element, 'AggregateSearchModal__filters__type');
+    expect(element.state.filter).toEqual('all');
+    TestUtils.Simulate.click(filterElements[1].getDOMNode());
+    expect(element.state.filter).toEqual('charities');
+    TestUtils.Simulate.click(filterElements[0].getDOMNode());
+    expect(element.state.filter).toEqual('pages');
+  });
 });
 
 describe('AggregateSearchModal with searchType prop set', function() {
-  it('renders a single filter based on the `searchType` prop', function() {
+  var filterElements;
+
+  beforeEach(function() {
     searchModal = <AggregateSearchModal autoFocus={ false } searchType="campaigns" />;
-    element     = TestUtils.renderIntoDocument(searchModal);
-
+    element = TestUtils.renderIntoDocument(searchModal);
     element.setState({ results: { foo: 'bar' }, isSearching: false });
+    filterElements = scryByClass(element, 'AggregateSearchModal__filters__type');
+  });
 
-    var filterElements = scryByClass(element, 'AggregateSearchModal__filters__type');
-
+  it('renders a single filter based on the `searchType` prop', function() {
     expect(filterElements.length).toBe(1);
     expect(filterElements[0].getDOMNode().textContent).toContain('Events');
+  });
+
+  it('the filter selection button is disabled (has no onclick behaviour)', function() {
+    expect(element.state.filter).toEqual('campaigns');
+    TestUtils.Simulate.click(filterElements[0].getDOMNode());
+    expect(element.state.filter).toEqual('campaigns');
   });
 });

--- a/src/components/search/AggregateSearchModal/index.js
+++ b/src/components/search/AggregateSearchModal/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _       = require('lodash');
 var async   = require('async');
@@ -34,6 +34,10 @@ module.exports = React.createClass({
     i18n: React.PropTypes.object,
     onClose: React.PropTypes.func.isRequired,
     onSelect: React.PropTypes.func,
+    minimumScore: React.PropTypes.shape({
+      all: React.PropTypes.number,
+      other: React.PropTypes.number
+    }),
     searchType: React.PropTypes.oneOf(['campaigns', 'charities', 'pages', 'all']),
     charityUids: React.PropTypes.array
   },
@@ -49,10 +53,10 @@ module.exports = React.createClass({
         charityAction: 'Visit Charity',
         supporterAction: 'Support',
         emptyLabel: {
-          pages: "We couldn't find any matching supporters",
-          charities: "We couldn't find any matching charities",
-          campaigns: "We couldn't find any matching events",
-          all: "We couldn't find any matching supporters, charities or events"
+          pages: 'We couldn\'t find any matching supporters',
+          charities: 'We couldn\'t find any matching charities',
+          campaigns: 'We couldn\'t find any matching events',
+          all: 'We couldn\'t find any matching supporters, charities or events'
         },
         noMore: 'No more results',
         loadMore: 'Show more',
@@ -229,9 +233,10 @@ module.exports = React.createClass({
       var selected = (type == this.state.filter);
       var classes = cx({
         'AggregateSearchModal__filters__type': true,
-        'AggregateSearchModal__filters__type-selected': selected
+        'AggregateSearchModal__filters__type--selected': selected
       });
-      var onClick = this.setFilter.bind(this, selected ? 'all' : type);
+
+      var onClick = _.size(filters) > 1 && this.setFilter.bind(this, selected ? 'all' : type);
       var count = this.state.counts[type];
       var numResults = count >= 0 ? this.t('numResults', { count: count }) : this.t('searching');
 
@@ -310,7 +315,7 @@ module.exports = React.createClass({
   renderInput: function() {
     return (
       <Input
-        className='AggregateSearchModal__input'
+        className="AggregateSearchModal__input"
         spacing="compact"
         autoFocus={ this.props.autoFocus }
         i18n={{ label: this.t('inputLabel'), name: 'aggregate_search_input' }}
@@ -324,7 +329,7 @@ module.exports = React.createClass({
   render: function() {
     return (
       <Overlay className="AggregateSearchModal__overlay" onClose={ this.props.onClose } showCloseButton={ false }>
-        <div className='AggregateSearchModal__header'>
+        <div className="AggregateSearchModal__header">
           <span className="AggregateSearchModal__title">{ this.t('title') }</span>
           { this.renderCloseButton() }
           { this.renderInput() }

--- a/src/components/search/AggregateSearchModal/style.scss
+++ b/src/components/search/AggregateSearchModal/style.scss
@@ -160,7 +160,13 @@
   }
 }
 
-.AggregateSearchModal__filters__type-selected {
+.AggregateSearchModal__filters__type--selected {
+  cursor: default;
+
+  &:hover {
+    color: $ehw-grey-light;
+  }
+
   @include media-max($breakpoint-xs) {
     border-color: $ehw-green-light;
   }

--- a/src/components/search/AggregateSearchResult/__tests__/AggregateSearchResult-test.js
+++ b/src/components/search/AggregateSearchResult/__tests__/AggregateSearchResult-test.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 jest.autoMockOff();
 

--- a/src/components/search/AggregateSearchResult/index.js
+++ b/src/components/search/AggregateSearchResult/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var React = require('react');
 

--- a/src/components/search/AggregateSearchResultCampaign/index.js
+++ b/src/components/search/AggregateSearchResultCampaign/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _             = require('lodash');
 var React         = require('react');
@@ -35,7 +35,11 @@ module.exports = React.createClass({
   renderDate: function () {
     var campaign = this.props.result;
     if (!campaign.display_start_at) {
-      return <div className="AggregateSearchResultCampaign__date" />;
+      return (
+        <div className="AggregateSearchResultCampaign__date">
+          <Icon icon="heart-o" className="AggregateSearchResultCampaign__icon" />
+        </div>
+      );
     }
 
     var date = new Date(campaign.display_start_at);
@@ -51,7 +55,7 @@ module.exports = React.createClass({
   renderNumSupporters: function () {
     var campaign = this.props.result;
     return campaign.page_count >= 20 && (
-      <span className='AggregateSearchResultCampaign__supporters'>
+      <span className="AggregateSearchResultCampaign__supporters">
         { this.t('numSupporters', { count: campaign.page_count }) }
       </span>
     );
@@ -60,7 +64,7 @@ module.exports = React.createClass({
   renderNumCharities: function () {
     var campaign = this.props.result;
     return campaign.charity_count >= 0 && (
-      <span className='AggregateSearchResultCampaign__charities'>
+      <span className="AggregateSearchResultCampaign__charities">
         { this.t('numCharities', { count: campaign.charity_count }) }
       </span>
     );
@@ -73,13 +77,13 @@ module.exports = React.createClass({
     return (
       <AggregateSearchResult url={ url } onSelect={ this.props.onSelect } result={ campaign }>
         { this.renderDate() }
-        <div className='AggregateSearchResultCampaign__content'>
-          <div className='AggregateSearchResultCampaign__header'>{ campaign.name }</div>
-          <div className='AggregateSearchResultCampaign__subheader'>
+        <div className="AggregateSearchResultCampaign__content">
+          <div className="AggregateSearchResultCampaign__header">{ campaign.name }</div>
+          <div className="AggregateSearchResultCampaign__subheader">
             { this.renderNumSupporters() }
             { this.renderNumCharities() }
           </div>
-          <p className='AggregateSearchResultCampaign__description'>{ campaign.description }</p>
+          <p className="AggregateSearchResultCampaign__description">{ campaign.description }</p>
         </div>
       </AggregateSearchResult>
     );

--- a/src/components/search/AggregateSearchResultCampaign/style.scss
+++ b/src/components/search/AggregateSearchResultCampaign/style.scss
@@ -88,3 +88,11 @@
   height: 42px;
   overflow: hidden;
 }
+
+.AggregateSearchResultCampaign__icon {
+  font-size: $x-5;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}

--- a/src/components/search/AggregateSearchResultCharity/index.js
+++ b/src/components/search/AggregateSearchResultCharity/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var _             = require('lodash');
 var React         = require('react');
@@ -36,8 +36,8 @@ module.exports = React.createClass({
 
   renderAvatar: function () {
     return (
-      <div className='AggregateSearchResultCharity__avatar'>
-        <Icon icon={ 'heart-o' } fixedWidth={ true } />
+      <div className="AggregateSearchResultCharity__avatar">
+        <Icon icon="heart-o" fixedWidth={ true } />
       </div>
     );
   },
@@ -46,7 +46,7 @@ module.exports = React.createClass({
     var charity = this.props.result;
 
     return charity.page_count >= 20 && (
-      <span className='AggregateSearchResultCharity__supporters'>
+      <span className="AggregateSearchResultCharity__supporters">
         { this.t('numSupporters', { count: charity.page_count }) }
       </span>
     );
@@ -58,12 +58,12 @@ module.exports = React.createClass({
     return (
       <AggregateSearchResult url={ charity.url } result={ charity } onSelect={ this.props.onSelect }>
         { this.renderLogo() || this.renderAvatar() }
-        <div className='AggregateSearchResultCharity__content'>
-          <div className='AggregateSearchResultCharity__header'>{ charity.name }</div>
-          <div className='AggregateSearchResultCharity__subheader'>
+        <div className="AggregateSearchResultCharity__content">
+          <div className="AggregateSearchResultCharity__header">{ charity.name }</div>
+          <div className="AggregateSearchResultCharity__subheader">
             { this.renderNumSupporters() }
           </div>
-          <p className='AggregateSearchResultCharity__description'>{ charity.description }</p>
+          <p className="AggregateSearchResultCharity__description">{ charity.description }</p>
         </div>
       </AggregateSearchResult>
     );

--- a/src/components/search/AggregateSearchResultPage/index.js
+++ b/src/components/search/AggregateSearchResultPage/index.js
@@ -1,11 +1,11 @@
-"use strict";
+'use strict';
 
-var _                           = require('lodash');
-var React                       = require('react');
-var Icon                        = require('../../helpers/Icon');
-var I18n                        = require('../../mixins/I18n');
-var pagesAPI                    = require('../../../api/pages');
-var AggregateSearchResult       = require('../AggregateSearchResult');
+var _                     = require('lodash');
+var React                 = require('react');
+var Icon                  = require('../../helpers/Icon');
+var I18n                  = require('../../mixins/I18n');
+var pagesAPI              = require('../../../api/pages');
+var AggregateSearchResult = require('../AggregateSearchResult');
 
 module.exports = React.createClass({
   displayName: 'AggregateSearchResultPage',
@@ -29,12 +29,11 @@ module.exports = React.createClass({
 
   renderProgressBar: function () {
     var page = this.props.result;
-    var progress = page.amount && page.target_cents > 0 &&
-      Math.min(Math.floor(page.amount.cents / page.target_cents * 100), 100) || 0;
+    var progress = page.amount && page.target_cents > 0 && Math.min(Math.floor(page.amount.cents / page.target_cents * 100), 100) || 0;
 
     return (
-      <div className='AggregateSearchResultPage__progress'>
-        <div className='AggregateSearchResultPage__progress__bar' style={{ width: progress + '%' }} />
+      <div className="AggregateSearchResultPage__progress">
+        <div className="AggregateSearchResultPage__progress__bar" style={{ width: progress + '%' }} />
       </div>
     );
   },
@@ -48,7 +47,7 @@ module.exports = React.createClass({
         target: page.target_cents / 100
       });
 
-    return !!raised_amount && <div className='AggregateSearchResultPage__amount'>{ raised_amount }</div>;
+    return !!raised_amount && <div className="AggregateSearchResultPage__amount">{ raised_amount }</div>;
   },
 
   renderRaisedFor: function () {
@@ -59,7 +58,7 @@ module.exports = React.createClass({
         campaign: page.campaign.name
       });
 
-    return <div className='AggregateSearchResultPage__for'>{ raised_for }</div>;
+    return <div className="AggregateSearchResultPage__for">{ raised_for }</div>;
   },
 
   render: function() {
@@ -67,11 +66,11 @@ module.exports = React.createClass({
 
     return (
       <AggregateSearchResult url={ page.url } onSelect={ this.props.onSelect } result={ page }>
-        <div className='AggregateSearchResultPage__avatar'>
+        <div className="AggregateSearchResultPage__avatar">
           <img src={ page.image.medium_image_url } />
         </div>
-        <div className='AggregateSearchResultPage__content'>
-          <div className='AggregateSearchResultPage__header'>
+        <div className="AggregateSearchResultPage__content">
+          <div className="AggregateSearchResultPage__header">
             { page.supporter.name }
             <span className="AggregateSearchResultPage__subheader">{ page.name }</span>
           </div>

--- a/src/docs.md
+++ b/src/docs.md
@@ -159,7 +159,7 @@ Country code of region, either 'au', 'ie', 'nz', 'uk' or 'us'.
 Object containing localised text.
 
 `minimumScore` (object)<br>
-Set the "fuzziness" of the search engine. A lower number will return more results. Default is set to minimumScore: `{ all: 0.15, other: 0.15 }`,
+Set the "fuzziness" of the search engine. A lower number will return more results. Default is set to: `{ all: 0.15, other: 0.15 }`,
 
 `searchType` (string)<br>
 Optional string used to constrain search results to a given type. Set to either 'campaigns', 'charities', 'pages', or 'all'. Default is set to 'all'.

--- a/src/docs.md
+++ b/src/docs.md
@@ -158,6 +158,9 @@ Country code of region, either 'au', 'ie', 'nz', 'uk' or 'us'.
 `i18n` (object)<br>
 Object containing localised text.
 
+`minimumScore` (object)<br>
+Set the "fuzziness" of the search engine. A lower number will return more results. Default is set to minimumScore: `{ all: 0.15, other: 0.15 }`,
+
 `searchType` (string)<br>
 Optional string used to constrain search results to a given type. Set to either 'campaigns', 'charities', 'pages', or 'all'. Default is set to 'all'.
 


### PR DESCRIPTION
Resolved some items after QA feedback:

- If a `searchType` has been defined then the filter buttons no longer trigger an onClick.
- Along with the above the hover effects for filter buttons are disabled.
- Documented the `'minimumScore` property. We needed to tweak this slightly in our implementation.
- Improved the style for campaign results that have no start date associated with them, prime example is BAU (everydayhero) result. Before it rendered as an empty square which just looked broken.
- Fixed a bunch of little lint warnings. Where do I collect my boy-scout badge? :smile:

![screen shot 2015-11-20 at 4 48 15 pm](https://cloud.githubusercontent.com/assets/859298/11293567/d004a78e-8fa6-11e5-96f2-5813f77d8273.png)
