### PR TITLE
[TA-8423] Add uuids param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "EverydayHero <edh-dev@everydayhero.com>",
   "name": "edh-widgets",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Widgets are small Javascript components that integrate with EverydayHero's API. These include search components and components for showing leaderboard and fundraising totals for campaigns, charities, and networks. Unlike iframe snippets, using widgets allows you to customise the base-level styling to suit your needs.",
   "license": "MIT",
   "main": "src/widgets.js",

--- a/src/api/__tests__/campaigns-test.js
+++ b/src/api/__tests__/campaigns-test.js
@@ -190,11 +190,17 @@ describe('campaigns', function() {
 
   describe('search', function() {
     it('searches for campaigns', function() {
-      var query = { searchTerm: 'bar', country: 'xy', page: 2, pageSize: 7 };
+      var query = {
+        searchTerm: 'bar',
+        country: 'xy',
+        page: 2,
+        pageSize: 7,
+        charityUuids: ['abc-123', 'xyz-456']
+      };
       var callback = jest.genMockFunction();
       campaigns.search(query, callback);
 
-      expect(getJSONP).toBeCalledWith('https://everydayhero.com/api/v2/search/campaigns.jsonp?q=bar&country_code=xy&page=2&page_size=7', callback, {timeout: 10000});
+      expect(getJSONP).toBeCalledWith('https://everydayhero.com/api/v2/search/campaigns.jsonp?q=bar&country_code=xy&page=2&page_size=7&charity_uuids=abc-123,xyz-456', callback, { timeout: 10000 });
       expect(callback).toBeCalledWith(results);
     });
   });

--- a/src/api/routes.js
+++ b/src/api/routes.js
@@ -19,7 +19,7 @@ var baseRoutes = {
   pages:                '{baseUrl}/api/v2/pages.jsonp?ids={pageIds}&campaign_id={campaignUid}&charity_ids={charityUid}&type={type}&include_footprint={includeFootprint}&page={page}&limit={limit}&start_created_at={start}&end_created_at={end}',
 
   searchAggregate:      '{baseUrl}/api/v2/search/aggregate.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
-  searchCampaigns:      '{baseUrl}/api/v2/search/campaigns.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}&charity_ids={charityUids}',
+  searchCampaigns:      '{baseUrl}/api/v2/search/campaigns.jsonp?q={searchTerm}&country_code={country}&page={page}&page_size={pageSize}&minimum_score={minimumScore}&charity_ids={charityUids}&charity_uuids={charityUuids}',
   searchCharities:      '{baseUrl}/api/v2/search/charities.jsonp?q={searchTerm}&country_code={country}&campaign_id={campaignUid}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
   searchPages:          '{baseUrl}/api/v2/search/pages.jsonp?q={searchTerm}&country_code={country}&campaign_id={campaignUid}&charity_id={charityUid}&type={pageType}&page={page}&page_size={pageSize}&minimum_score={minimumScore}',
 

--- a/src/components/search/AggregateSearchModal/index.js
+++ b/src/components/search/AggregateSearchModal/index.js
@@ -39,7 +39,8 @@ module.exports = React.createClass({
       other: React.PropTypes.number
     }),
     searchType: React.PropTypes.oneOf(['campaigns', 'charities', 'pages', 'all']),
-    charityUids: React.PropTypes.array
+    charityUids: React.PropTypes.array,
+    charityUuids: React.PropTypes.array
   },
 
   getDefaultProps: function() {
@@ -77,7 +78,8 @@ module.exports = React.createClass({
       },
       pageSize: 10,
       searchType: 'all',
-      charityUids: []
+      charityUids: [],
+      charityUuids: []
     };
   },
 
@@ -131,7 +133,8 @@ module.exports = React.createClass({
       page: page || 1,
       pageSize: this.props.pageSize,
       minimumScore: this.props.minimumScore[this.state.filter] || this.props.minimumScore.other,
-      charityUids: this.props.charityUids
+      charityUids: this.props.charityUids,
+      charityUuids: this.props.charityUuids
     }, this.updateResults);
 
     this.setState({
@@ -191,7 +194,8 @@ module.exports = React.createClass({
       page: 1,
       pageSize: 1,
       minimumScore: this.props.minimumScore.other,
-      charityUids: this.props.charityUids
+      charityUids: this.props.charityUids,
+      charityUuids: this.props.charityUuids
     };
 
     var types = this.props.searchType === 'all' ? ['campaigns', 'charities', 'pages'] : [this.props.searchType];

--- a/src/docs.md
+++ b/src/docs.md
@@ -167,6 +167,9 @@ Optional string used to constrain search results to a given type. Set to either 
 `charityUids` (array)<br>
 Optional array used to filter campaign results by given charity uids.
 
+`charityUuids` (array)<br>
+Optional array used to filter campaign results by given charity uuids. Can be used as an alternative to using the regular `charityUids` parameter.
+
 `onSelect` (function)<br>
 Optional function called on selecting a result. Takes a single argument that returns a full API response object for the selected result.
 


### PR DESCRIPTION
In NFP we have something called  `beneficiaryId`.  In order to filter campaign results by "charity" in our application we need to pass the `beneficiaryId` as a parameter instead of a regular `charityUid`.

It happens that NFP's `beneficiaryId`  === `charityUuid` in supporter.