### PR TITLE
GitHub 2FA support on deploy

### DIFF
--- a/bin/update_docs
+++ b/bin/update_docs
@@ -2,7 +2,7 @@
 
 set -e
 
-export DOCS_REPO=https://github.com/everydayhero/public-api-docs.git
+export DOCS_REPO=git@github.com:everydayhero/public-api-docs.git
 
 rm -rf docs
 git clone $DOCS_REPO docs 2>&1


### PR DESCRIPTION
GitHub users with 2FA enabled cannot run a deploy because the docs repo clone is done through https, which isn't supported with 2FA.

Switched `DOCS_REPO` to the ssh address instead to rectify.