### PR TITLE
Handle empty arrays aswell as other falsey values

### DIFF
--- a/src/components/mixins/Leaderboard.js
+++ b/src/components/mixins/Leaderboard.js
@@ -22,7 +22,7 @@ module.exports = {
     } else {
       if (props.campaignUids) {
         endpoint = campaigns.leaderboardByUids.bind(campaigns, props.campaignUids, props.charityUid);
-      } else if (props.campaignUid && (props.groupValues || props.groupValue)) {
+      } else if (props.campaignUid && (!_.isEmpty(props.groupValues) || props.groupValue)) {
         endpoint = campaigns.leaderboardDynamic.bind(campaigns, props.campaignUid, props.groupValue);
       } else if (props.campaignUid) {
         endpoint = campaigns.leaderboard.bind(campaigns, props.campaignUid, props.charityUid);


### PR DESCRIPTION
Individual Leaderboard components have been broken since v1.7.0. The problem was caused by `groupValues` sometimes being set as an empty array and other times being `undefined`.

This handles both cases.