### PR TITLE
Set eslint version to avoid issues with 2.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-preset-react": "^6.3.13",
     "browserify": "~13.0.0",
     "compression": "~1.6.1",
+    "eslint": "^2.2.0",
     "eslint-plugin-react": "^4.1.0",
     "express": "~4.13.4",
     "gulp": "~3.9.1",


### PR DESCRIPTION
Relates to the discussion over here: https://github.com/everydayhero/react-widgets/pull/387