### PR TITLE
Set strict version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "babel-preset-react": "^6.3.13",
     "browserify": "~13.0.0",
     "compression": "~1.6.1",
-    "eslint": "^2.2.0",
+    "eslint": "2.2.0",
     "eslint-plugin-react": "^4.1.0",
     "express": "~4.13.4",
     "gulp": "~3.9.1",


### PR DESCRIPTION
Every version after 2.2.x appears to be broken for now. Let's revisit this dependency once they have fixed issues with `fb-estraverse` 