### PR TITLE
Remove unused variable

### DIFF
--- a/src/components/totals/FundsRaised/__tests__/FundsRaised-test.js
+++ b/src/components/totals/FundsRaised/__tests__/FundsRaised-test.js
@@ -274,7 +274,7 @@ describe('FundsRaised', function() {
 
     it('fires the callback after API data is fetched', function() {
       var cb = jest.genMockFunction();
-      var element = TestUtils.renderIntoDocument(<FundsRaised charityUid="au-24" onLoad={ function(res) { cb(res) } } />);
+      TestUtils.renderIntoDocument(<FundsRaised charityUid="au-24" onLoad={ function(res) { cb(res) } } />);
       expect(cb.mock.calls.length).toBe(1);
       expect(cb.mock.calls[0].length).toBe(1);
     });


### PR DESCRIPTION
I did a smart and forgot to remove an unused variable. This doesn't matter much in testing, but will cause an attempt to deploy to fail.