### PR TITLE
Preserve z-index when minifying

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,7 +66,7 @@ gulp.task('styles', function() {
     .pipe(sourcemaps.init())
     .pipe(sass())
     .pipe(autoprefixer())
-    .pipe(processor())
+    .pipe(processor({ zindex: false }))
     .pipe(rename('widgets-' + pkg.version + '.css'))
     .pipe(sourcemaps.write())
     .pipe(gulp.dest('public'))


### PR DESCRIPTION
The version of cssnano used normalises the z-index values (which might sometimes be nice), it does however change the z-index of the search overlay from 1000 to 3 (which then doesn't appear in edh portal)

While a nice idea it feels fragile when included amongst lots of other sites etc

More info here https://github.com/ben-eb/gulp-cssnano/issues/8