### PR TITLE
Make search widgets properties more consistent

### DIFF
--- a/src/components/search/CharitySearchModal/index.js
+++ b/src/components/search/CharitySearchModal/index.js
@@ -142,13 +142,12 @@ module.exports = React.createClass({
     this.props.resizeCallback();
   },
 
-  selectHandler: function(result) {
+  selectHandler: function(event, result) {
     this.onClose();
 
-    if (this.props.action == 'custom' && this.props.onSelect) {
+    if (this.props.action === 'custom' && this.props.onSelect) {
+      event.preventDefault();
       this.props.onSelect(result.charity);
-    } else {
-      window.location = result.url;
     }
   },
 

--- a/src/components/search/PageSearchModal/__tests__/PageSearchModal-test.js
+++ b/src/components/search/PageSearchModal/__tests__/PageSearchModal-test.js
@@ -134,7 +134,7 @@ describe('PageSearchModal', function() {
   it('allows custom callback on page select', function() {
     var onClose = jest.genMockFunction();
     var callback = jest.genMockFunction();
-    var pageSearchModal = <PageSearchModal autoFocus={ false } onClose={ onClose } onSelect={ callback } />;
+    var pageSearchModal = <PageSearchModal autoFocus={ false } onClose={ onClose } action="custom" onSelect={ callback } />;
     var element = TestUtils.renderIntoDocument(pageSearchModal);
     element.setState({ results: [page] });
 

--- a/src/components/search/PageSearchModal/index.js
+++ b/src/components/search/PageSearchModal/index.js
@@ -19,6 +19,7 @@ module.exports = React.createClass({
     onClose: React.PropTypes.func.isRequired,
     action: React.PropTypes.oneOf(['visit', 'custom']),
     onSelect: React.PropTypes.func,
+    resizeCallback: React.PropTypes.func,
     pageType: React.PropTypes.oneOf(['all', 'team', 'user']),
     groupValues: React.PropTypes.array,
     searchTerm: React.PropTypes.string
@@ -31,6 +32,7 @@ module.exports = React.createClass({
       campaignUid: '',
       charityUid: '',
       groupValues: [],
+      resizeCallback: function() {},
       defaultI18n: {
         title: 'Search for a Supporter Page',
         selectAction: 'Support',
@@ -46,6 +48,8 @@ module.exports = React.createClass({
     if (this.props.searchTerm) {
       this.search(this.props.searchTerm);
     }
+
+    this.props.resizeCallback();
   },
 
   getInitialState: function() {

--- a/src/components/search/PageSearchModal/index.js
+++ b/src/components/search/PageSearchModal/index.js
@@ -17,6 +17,7 @@ module.exports = React.createClass({
     country: React.PropTypes.oneOf(['au', 'ie', 'nz', 'uk', 'us']),
     i18n: React.PropTypes.object,
     onClose: React.PropTypes.func.isRequired,
+    action: React.PropTypes.oneOf(['visit', 'custom']),
     onSelect: React.PropTypes.func,
     pageType: React.PropTypes.oneOf(['all', 'team', 'user']),
     groupValues: React.PropTypes.array,
@@ -25,6 +26,7 @@ module.exports = React.createClass({
 
   getDefaultProps: function() {
     return {
+      action: 'visit',
       autoFocus: true,
       campaignUid: '',
       charityUid: '',
@@ -111,14 +113,21 @@ module.exports = React.createClass({
     } else {
       this.setState(this.getInitialState());
     }
+
+    this.props.resizeCallback();
   },
 
-  selectHandler: function(page, event) {
+  onClose: function() {
     this.props.onClose();
+    this.props.resizeCallback();
+  },
 
-    if (this.props.onSelect) {
+  selectHandler: function(event, result) {
+    this.onClose();
+
+    if (this.props.action === 'custom' && this.props.onSelect) {
       event.preventDefault();
-      this.props.onSelect(page);
+      this.props.onSelect(result);
     }
   },
 

--- a/src/components/search/SearchResult/__tests__/SearchResult-test.js
+++ b/src/components/search/SearchResult/__tests__/SearchResult-test.js
@@ -32,7 +32,8 @@ describe('SearchResult', function() {
     var element = findByClass(component, 'SearchResult');
     TestUtils.Simulate.click(element);
 
-    expect(callback.mock.calls[0][0]).toBe(result);
+    expect(callback.mock.calls[0][0]).toBeTruthy();
+    expect(callback.mock.calls[0][1]).toBe(result);
     expect(callback.mock.calls[0].length).toBe(2);
   });
 });

--- a/src/components/search/SearchResult/index.js
+++ b/src/components/search/SearchResult/index.js
@@ -11,7 +11,7 @@ module.exports = React.createClass({
   },
 
   clickHandler: function(event) {
-    this.props.onSelect(this.props.result, event);
+    this.props.onSelect(event, this.props.result);
   },
 
   render: function() {

--- a/src/docs.md
+++ b/src/docs.md
@@ -219,6 +219,9 @@ Action to perform on charity select, either 'visit' (default), 'donate', 'fundra
 `onSelect` (function)<br>
 Function called on selecting a result. `action` must be set to `'custom'`.<br>
 
+`resizeCallback` (function)<br>
+Function called when search results change. Useful for running code based on how many results are returned.
+
 `campaignUid` (string)<br>
 Campaign uid to filter charity results.
 
@@ -271,8 +274,14 @@ The supporter page search modal widget allows you to search for a supporter page
 }
 ```
 
+`action` (string)<br>
+Action to perform on charity select, either 'visit' (default) or 'custom'.
+
 `onSelect` (function)<br>
-Called on selecting a result. Default redirects to supporter page.
+Function called on selecting a result. `action` must be set to `'custom'`.<br>
+
+`resizeCallback` (function)<br>
+Function called when search results change. Useful for running code based on how many results are returned.
 
 `campaignUid` (string)<br>
 Campaign uid to filter page results.


### PR DESCRIPTION
This makes the API (and behaviour) for charity and page search widgets a little more consistent.

On `master` currently the charity search widget appears to not prevent the default action when a custom `onSelect` function is applied. So, you could never see your custom action since the browser will immediately follow the url given to a search result anchor tag. This fixes that.

Also added the `resizeCallback` to the page search modal for consistency sake – though I do feel it is a bit poorly named.