### PR TITLE
buildkite the widgets

### DIFF
--- a/.buildkite/bin/announce
+++ b/.buildkite/bin/announce
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -eux
+
+arr[0]="balloon"
+arr[1]="alien"
+arr[2]="robot_face"
+arr[3]="tongue"
+arr[4]="bikini"
+
+rand=$[ $RANDOM % 5 ]
+
+curl \
+${SLACK_WEBHOOK_URL} \
+-X POST \
+-H 'Content-Type: application/json' \
+-d @/dev/stdin <<JSON
+{
+  "text": "[<${BUILDKITE_BUILD_URL}|react-widgets #${BUILDKITE_BUILD_NUMBER}>] :balloon: edh-widgets has been released! :partyparrot:",
+  "channel": "#javascript",
+  "username": "EDH-Widgets",
+  "icon_emoji": ":${arr[$rand]}:"
+}
+JSON

--- a/.buildkite/bin/build
+++ b/.buildkite/bin/build
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+docker build --pull --tag "quay.io/everydayhero/edh-widgets:${BUILDKITE_COMMIT}" .
+docker push "quay.io/everydayhero/edh-widgets:${BUILDKITE_COMMIT}"

--- a/.buildkite/bin/deploy
+++ b/.buildkite/bin/deploy
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -eux
+
+docker-compose -f .buildkite/docker-compose.yml run widgets ./bin/deploy

--- a/.buildkite/bin/test
+++ b/.buildkite/bin/test
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+docker-compose -f .buildkite/docker-compose.yml run widgets npm run test

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -1,2 +1,12 @@
 widgets:
   image: quay.io/everydayhero/edh-widgets:${BUILDKITE_COMMIT}
+  environment:
+    - AWS_KEY
+    - AWS_SECRET
+    - NPM_USER
+    - NPM_PASS
+    - NPM_EMAIL
+    - SLACK_WEBHOOK_URL
+    - BUILD_URL
+    - BUILDKITE_BUILD_URL
+    - BUILDKITE_BUILD_NUMBER

--- a/.buildkite/docker-compose.yml
+++ b/.buildkite/docker-compose.yml
@@ -1,0 +1,2 @@
+widgets:
+  image: quay.io/everydayhero/edh-widgets:${BUILDKITE_COMMIT}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,18 +15,19 @@ steps:
     agents:
       queue: native
 
+  - name: ":rocket: Publish"
+    type: "manual"
+
   - type: "waiter"
 
   - name: ":package: Deploy"
-    command: "bin/buildkite bin/only-for-version-releases bin/ci run bin/deploy"
-    branches: "master"
+    command: "./.buildkite/bin/deploy"
     agents:
       queue: native
 
   - type: "waiter"
 
   - name: ":loudspeaker:"
-    command: "bin/buildkite bin/only-for-version-releases bin/ci announce released"
-    branches: "master"
+    command: "./.buildkite/bin/announce"
     agents:
       queue: native

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,31 @@
+---
+steps:
+  - type: "waiter"
+
+  - name: ":docker:"
+    command: "bin/buildkite bin/ci build"
+    agents:
+      queue: native
+
+  - type: "waiter"
+
+  - name: ":pill:"
+    command: "bin/buildkite bin/ci run npm test"
+    agents:
+      queue: native
+
+  - type: "waiter"
+
+  - name: ":package: Deploy"
+    command: "bin/buildkite bin/only-for-version-releases bin/ci run bin/deploy"
+    branches: "master"
+    agents:
+      queue: native
+
+  - type: "waiter"
+
+  - name: ":loudspeaker:"
+    command: "bin/buildkite bin/only-for-version-releases bin/ci announce released"
+    branches: "master"
+    agents:
+      queue: native

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,8 +3,9 @@ steps:
   - type: "waiter"
 
   - name: ":docker:"
-    command: "bin/buildkite bin/ci build"
+    command: ".buildkite/bin/build"
     agents:
+      docker: builder
       queue: native
 
   - type: "waiter"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,7 +11,7 @@ steps:
   - type: "waiter"
 
   - name: ":pill:"
-    command: "bin/buildkite bin/ci run npm test"
+    command: ".buildkite/bin/test"
     agents:
       queue: native
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 npm-debug.log
 /docs
 buildkite-script-*
+/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM node:0.10.32
+FROM node:5
 
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+WORKDIR /usr/local/src
 
-ADD . /usr/src/app
+COPY package.json /usr/local/src
 RUN npm install
 
-CMD "bin/bash"
+COPY . /usr/local/src

--- a/bin/deploy
+++ b/bin/deploy
@@ -7,4 +7,4 @@ bin/update_docs
 # Publish to npm
 echo -e "$NPM_USER\n$NPM_PASS\n$NPM_EMAIL" | npm login
 node_modules/.bin/gulp transpile
-npm publish transpiled
+npm publish dist

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,8 +1,10 @@
-et -euo pipefail
+#!/bin/bash
+
+set -euo pipefail
 
 # Deploy assets
 node_modules/.bin/gulp deploy_assets
-bin/update_docs
+# bin/update_docs
 
 # Publish to npm
 echo -e "$NPM_USER\n$NPM_PASS\n$NPM_EMAIL" | npm login

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,10 @@
+et -euo pipefail
+
+# Deploy assets
+node_modules/.bin/gulp deploy_assets
+bin/update_docs
+
+# Publish to npm
+echo -e "$NPM_USER\n$NPM_PASS\n$NPM_EMAIL" | npm login
+node_modules/.bin/gulp transpile
+npm publish transpiled

--- a/bin/update_docs
+++ b/bin/update_docs
@@ -7,6 +7,8 @@ export DOCS_REPO=git@github.com:everydayhero/public-api-docs.git
 rm -rf docs
 git clone $DOCS_REPO docs 2>&1
 
+gulp docs
+
 cp public/docs.md docs/source/index.md
 
 export COMMENT=`git log -n 1 --format='%h %s'`

--- a/gulp_tasks/transpile.js
+++ b/gulp_tasks/transpile.js
@@ -1,0 +1,41 @@
+var gulp = require("gulp");
+var babel = require("gulp-babel");
+var clean = require('gulp-clean');
+var sourceDirectories = [
+  "src",
+  "scss",
+];
+
+var sourceMatcher = `{${sourceDirectories.join(",")}}`;
+var destination = 'dist';
+
+gulp.task("transpile", ['build-transpile'], function() {
+  return gulp.src( destination + '/src', {read: false})
+    .pipe(clean());
+});
+
+gulp.task("build-transpile", ['transpile-js', 'transpile-scss', 'transpile-images'], function() {
+  return gulp.src(['package.json', destination + '/src/**/*.*']).pipe(gulp.dest(destination));
+});
+
+
+gulp.task("transpile-js", function () {
+  return gulp.src([
+      `src/**/*.js`,
+      `!src/**/*-test.js`,
+    ])
+    .pipe(babel())
+    .pipe(gulp.dest(destination));
+});
+
+gulp.task('transpile-scss', function() {
+  return gulp
+    .src([`${sourceMatcher}/**/*.{scss,sass}`, 'common.scss', 'assets.scss'])
+    .pipe(gulp.dest(destination))
+});
+
+gulp.task('transpile-images', function() {
+  return gulp
+    .src('./images/*')
+    .pipe(gulp.dest(`${destination}/images`));
+});

--- a/gulp_tasks/transpile.js
+++ b/gulp_tasks/transpile.js
@@ -14,8 +14,8 @@ gulp.task("transpile", ['build-transpile'], function() {
     .pipe(clean());
 });
 
-gulp.task("build-transpile", ['transpile-js', 'transpile-scss', 'transpile-images'], function() {
-  return gulp.src(['package.json', destination + '/src/**/*.*']).pipe(gulp.dest(destination));
+gulp.task("build-transpile", ['transpile-js', 'transpile-scss', 'copy-images', 'copy-bin-stubs'], function() {
+  return gulp.src(['package.json', 'README.md', 'index.html']).pipe(gulp.dest(destination));
 });
 
 
@@ -25,7 +25,7 @@ gulp.task("transpile-js", function () {
       `!src/**/*-test.js`,
     ])
     .pipe(babel())
-    .pipe(gulp.dest(destination));
+    .pipe(gulp.dest(destination + '/src'));
 });
 
 gulp.task('transpile-scss', function() {
@@ -34,8 +34,14 @@ gulp.task('transpile-scss', function() {
     .pipe(gulp.dest(destination))
 });
 
-gulp.task('transpile-images', function() {
+gulp.task('copy-images', function() {
   return gulp
-    .src('./images/*')
-    .pipe(gulp.dest(`${destination}/images`));
+    .src('./src/images/*')
+    .pipe(gulp.dest(`${destination}/src/images`));
+});
+
+gulp.task('copy-bin-stubs', function() {
+  return gulp
+    .src('./bin/*')
+    .pipe(gulp.dest(`${destination}/bin/`));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ var replace      = require('gulp-replace')
 var pkg          = require('./package')
 var request      = require('superagent')
 var fs           = require('fs')
+var babel = require("gulp-babel");
 
 // stylesheets
 var sass         = require('gulp-sass')
@@ -22,6 +23,9 @@ var uglify       = require('gulp-uglify')
 var eslint       = require('gulp-eslint')
 var buffer       = require('vinyl-buffer')
 var source       = require('vinyl-source-stream')
+
+//TASKS
+require('./gulp_tasks/transpile');
 
 // html
 var inject       = require('gulp-inject')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "EverydayHero <edh-dev@everydayhero.com>",
   "name": "edh-widgets",
-  "version": "3.1.2",
+  "version": "3.1.6",
   "description": "Widgets are small Javascript components that integrate with EverydayHero's API. These include search components and components for showing leaderboard and fundraising totals for campaigns, charities, and networks. Unlike iframe snippets, using widgets allows you to customise the base-level styling to suit your needs.",
   "license": "MIT",
   "main": "src/widgets.js",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "gulp": "~3.9.1",
     "gulp-autoprefixer": "~3.1.0",
     "gulp-awspublish": "~3.2.0",
+    "gulp-babel": "^6.1.2",
+    "gulp-clean": "^0.3.2",
     "gulp-concat": "~2.6.0",
     "gulp-cssnano": "^2.1.1",
     "gulp-eslint": "^2.0.0",


### PR DESCRIPTION
Getting rid of Semaphore
Now using buildkite. 

Includes publishing to AWS and NPM
Publishing to AWS would normally include updating the docs, but for some reason the buildkite agents are not configured correctly and DEV_OP-team is too busy to fix it.