### PR TITLE
Move clean into own task

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -8,5 +8,6 @@ node_modules/.bin/gulp deploy_assets
 
 # Publish to npm
 echo -e "$NPM_USER\n$NPM_PASS\n$NPM_EMAIL" | npm login
+node_modules/.bin/gulp clean
 node_modules/.bin/gulp transpile
 npm publish dist

--- a/gulp_tasks/transpile.js
+++ b/gulp_tasks/transpile.js
@@ -4,12 +4,12 @@ var clean = require('gulp-clean')
 
 var destination = 'dist'
 
-gulp.task('transpile', ['build-transpile'], function () {
+gulp.task('clean', function () {
   return gulp.src(destination + '/src', {read: false})
     .pipe(clean())
 })
 
-gulp.task('build-transpile', ['transpile-js', 'transpile-scss', 'copy-images', 'copy-bin-stubs'], function () {
+gulp.task('transpile', ['transpile-js', 'transpile-scss', 'copy-images', 'copy-bin-stubs'], function () {
   return gulp.src(['package.json', 'README.md', 'index.html']).pipe(gulp.dest(destination))
 })
 


### PR DESCRIPTION
**Problem**

Install RW via NPM and the directory had no JS in it, just all the SCSS files. It looked like it was doing the actual transpiling (gulp build-transpile) as a dependency of the main task (gulp transpile), which then used gulp-clean to wipe out the directory after the files were transpiled.

**Solution**

Moved gulp clean into it's own task and run that first to clean out the directory before then transpiling the files, assuming that was the purpose?

Tested and works locally, with the dist folder now having all the files, transpiled and ready to go.