### PR TITLE
Allow href and onClick props to be used together

### DIFF
--- a/src/components/callstoaction/CallToActionButton/__tests__/CallToActionButton-test.js
+++ b/src/components/callstoaction/CallToActionButton/__tests__/CallToActionButton-test.js
@@ -19,7 +19,12 @@ describe('CallToActionButton', function () {
       }
 
       component = TestUtils.renderIntoDocument(
-        <CallToActionButton kind='cta' label='Get Started' icon='chevron-right' onClick={onClick} />
+        <CallToActionButton
+          kind='cta'
+          label='Get Started'
+          icon='chevron-right'
+          onClick={onClick}
+          href='https://everydayhero.com/' />
       )
     })
 
@@ -28,7 +33,7 @@ describe('CallToActionButton', function () {
     })
 
     it('handles click events', function () {
-      var node = scryByTag(component, 'button')[0]
+      var node = scryByTag(component, 'a')[0]
       TestUtils.Simulate.mouseUp(node)
 
       expect(clicked).toBe(true)

--- a/src/components/callstoaction/CallToActionButton/index.js
+++ b/src/components/callstoaction/CallToActionButton/index.js
@@ -42,7 +42,6 @@ export default React.createClass({
 
   handleClick: function (e) {
     if (this.props.onClick) {
-      e.preventDefault()
       this.props.onClick(e)
     }
   },
@@ -75,8 +74,8 @@ export default React.createClass({
         to={href}
         params={props.params}
         href={href}
-        onMouseUp={!href && this.handleClick}
-        onTouchStart={!href && this.handleClick}>
+        onMouseUp={this.handleClick}
+        onTouchStart={this.handleClick}>
         <Icon className='CallToActionButton__icon' icon={props.icon} />
         <span className='CallToActionButton__label'>
           { props.label || props.children }


### PR DESCRIPTION
This will allow consumers of the `CallToActionButton` component to use both the `href` and `onClick` props together.

Useful in the case where you want the button to behave as a link but still execute some JavaScript.