### PR TITLE
Fix ReactCSSTransitionGroup errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "everydayhero <edh-dev@everydayhero.com>",
   "name": "edh-widgets",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Widgets are small Javascript components that integrate with everydayhero's API. These include search components and components for showing leaderboard and fundraising totals for campaigns, charities, and networks. Unlike iframe snippets, using widgets allows you to customise the base-level styling to suit your needs.",
   "license": "MIT",
   "main": "src/widgets.js",

--- a/src/components/events/Goals/index.js
+++ b/src/components/events/Goals/index.js
@@ -46,9 +46,9 @@ export default React.createClass({
 
   renderCampaigns: function () {
     return (
-      this.state.campaigns.map(function (campaign) {
+      this.state.campaigns.map(function (campaign, index) {
         return (
-          <CampaignGoalItem name={campaign.name} goal={campaign.goal} count={campaign.count} />
+          <CampaignGoalItem key={index} name={campaign.name} goal={campaign.goal} count={campaign.count} />
         )
       })
     )

--- a/src/components/leaderboards/Leaderboard/index.js
+++ b/src/components/leaderboards/Leaderboard/index.js
@@ -106,6 +106,8 @@ export default React.createClass({
       <ReactCSSTransitionGroup
         className='Leaderboard__items'
         transitionName='Leaderboard__animation'
+        transitionEnterTimeout={666}
+        transitionLeaveTimeout={100}
         component='ol'>
         {
           board.map(function (item) {

--- a/src/components/leaderboards/TeamLeaderboard/index.js
+++ b/src/components/leaderboards/TeamLeaderboard/index.js
@@ -104,6 +104,8 @@ export default React.createClass({
     return (
       <ReactCSSTransitionGroup
         transitionName='TeamLeaderboard__animation'
+        transitionEnterTimeout={666}
+        transitionLeaveTimeout={100}
         component='ol'
         className='TeamLeaderboard__items'>
         {

--- a/src/components/sharing/ShareButton/index.js
+++ b/src/components/sharing/ShareButton/index.js
@@ -126,7 +126,10 @@ export default React.createClass({
           { this.renderIcon() }
           <span className='ShareButton__label'>{ buttonLabel }</span>
         </div>
-        <ReactCSSTransitionGroup transitionName='ShareButton__transition' transitionEnter={false}>
+        <ReactCSSTransitionGroup
+          transitionName='ShareButton__transition'
+          transitionLeaveTimeout={300}
+          transitionEnter={false}>
           { this.renderShareBox() }
         </ReactCSSTransitionGroup>
       </div>

--- a/src/scss/_version.scss
+++ b/src/scss/_version.scss
@@ -1,1 +1,1 @@
-$ehw-version: "-3.9.0";
+$ehw-version: "-3.9.1";


### PR DESCRIPTION
This resolves a breaking issue experienced on a client site where anchor tags had default transition styles applied, e.g.

```
.classname a {
  transition: text-decoration 200ms ease;
}
```

This prevented `Leaderboard` & `TeamLeaderboard` paging from working consistently.

Also silences some warnings.