### PR TITLE
Ability to hide or show supporter name on search result

### DIFF
--- a/src/components/search/PageSearchModal/index.js
+++ b/src/components/search/PageSearchModal/index.js
@@ -21,6 +21,7 @@ export default React.createClass({
     resizeCallback: React.PropTypes.func,
     pageType: React.PropTypes.oneOf(['all', 'team', 'user']),
     groupValues: React.PropTypes.array,
+    showSupporterName: React.PropTypes.bool,
     searchTerm: React.PropTypes.string
   },
 
@@ -148,6 +149,7 @@ export default React.createClass({
         pagination={this.state.pagination}
         results={this.state.results}
         resultComponent={PageSearchResult}
+        resultComponentProps={{ showSupporterName: this.props.showSupporterName }}
         searchTerm={this.props.searchTerm} />
     )
   }

--- a/src/components/search/PageSearchResult/index.js
+++ b/src/components/search/PageSearchResult/index.js
@@ -9,7 +9,14 @@ export default React.createClass({
   propTypes: {
     onSelect: React.PropTypes.func,
     result: React.PropTypes.object.isRequired,
-    selectAction: React.PropTypes.string.isRequired
+    selectAction: React.PropTypes.string.isRequired,
+    showSupporterName: React.PropTypes.bool
+  },
+
+  getDefaultProps: function () {
+    return {
+      showSupporterName: true
+    }
   },
 
   render: function () {
@@ -24,7 +31,7 @@ export default React.createClass({
         </div>
         <div className='PageSearchResult__content'>
           <div className='PageSearchResult__header'>
-            { page.name } <span className='PageSearchResult__subheader'> – { page.supporter.name }</span>
+            { page.name } {props.showSupporterName && <span className='PageSearchResult__subheader'> – { page.supporter.name }</span>}
           </div>
           <p className='PageSearchResult__description'>{ page.charity.name }</p>
           <div className='PageSearchResult__footer'>{ campaignName }</div>

--- a/src/components/search/SearchModal/index.js
+++ b/src/components/search/SearchModal/index.js
@@ -21,6 +21,7 @@ export default React.createClass({
     pagination: React.PropTypes.object,
     results: React.PropTypes.arrayOf(React.PropTypes.object),
     resultComponent: React.PropTypes.func.isRequired,
+    resultComponentProps: React.PropTypes.object,
     selectAction: React.PropTypes.string,
     searchTerm: React.PropTypes.string
   },
@@ -71,6 +72,7 @@ export default React.createClass({
         onSelect={props.onSelect}
         results={props.results}
         resultComponent={props.resultComponent}
+        resultComponentProps={props.resultComponentProps}
         selectAction={props.selectAction} />)
 
     return (

--- a/src/components/search/SearchResults/index.js
+++ b/src/components/search/SearchResults/index.js
@@ -12,6 +12,7 @@ export default React.createClass({
     onSelect: React.PropTypes.func,
     results: React.PropTypes.arrayOf(React.PropTypes.object),
     resultComponent: React.PropTypes.func.isRequired,
+    resultComponentProps: React.PropTypes.object,
     selectAction: React.PropTypes.string
   },
 
@@ -33,6 +34,7 @@ export default React.createClass({
 
     var props = this.props
     var Result = props.resultComponent
+    var resultComponentProps = props.resultComponentProps
     var selectAction = props.selectAction || this.t('selectAction')
 
     return _.map(this.props.results || [], function (result) {
@@ -41,7 +43,8 @@ export default React.createClass({
           key={result.id}
           onSelect={props.onSelect}
           result={result}
-          selectAction={selectAction} />
+          selectAction={selectAction}
+          {...resultComponentProps} />
       )
     })
   },


### PR DESCRIPTION
We needed the ability to hide the supporter's full name as this was causing privacy issues with pages in school based programs like Jump Rope. In these campaigns, the page is created by the parent, and the page is the child's first name and last initial e.g. "Child N". With the widget however, it is showing the user's full name which means the child's full name could be figured out e.g. it shows "Child N - Parent Name".

The `PageSearchResult` component is implemented internally in multiple nested components, so it wasn't as simple as passing a simple prop in and setting it. I had to add a `resultComponentProps` that gets passed down and eventually spread onto the final `resultComponent`. In our case we are forwarding on a `showSupporterName` prop, which when set to false, hides the full supporter name.