### PR TITLE
Hide date square when no start date exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "everydayhero <edh-dev@everydayhero.com>",
   "name": "edh-widgets",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Widgets are small Javascript components that integrate with everydayhero's API. These include search components and components for showing leaderboard and fundraising totals for campaigns, charities, and networks. Unlike iframe snippets, using widgets allows you to customise the base-level styling to suit your needs.",
   "license": "MIT",
   "main": "src/widgets.js",

--- a/src/components/events/Event/index.js
+++ b/src/components/events/Event/index.js
@@ -128,20 +128,22 @@ export default React.createClass({
         <div className={'Event__base ' + this.state.activeClass} style={{ backgroundImage: bg }}>
           <div className='Event__blur' style={{ backgroundImage: blur }} />
           <div className='Event__gradient' />
-          <ul className='Event__date DateBox'>
-            <li className='DateBox__day' >
-              {/* Heroix/NFP does *not* store dates with Timezone information. This means the 'utc' date we receive
-                  is actually the date as selected by the user in NFP or Heroix when configuring the campaign. If
-                  we don't use getUTCDate javascript will helpfully convert to the browser's locale, meaning in the US
-                  they see dates one day earlier than they selected when configuring the campaign.
-               */
-              }
-              { date.getUTCDate() }
-            </li>
-            <li className='DateBox__month-year'>
-              { t('months')[date.getUTCMonth()] } { date.getUTCFullYear() }
-            </li>
-          </ul>
+          {props.date &&
+            <ul className='Event__date DateBox'>
+              <li className='DateBox__day'>
+                {/* Heroix/NFP does *not* store dates with Timezone information. This means the 'utc' date we receive
+                    is actually the date as selected by the user in NFP or Heroix when configuring the campaign. If
+                    we don't use getUTCDate javascript will helpfully convert to the browser's locale, meaning in the US
+                    they see dates one day earlier than they selected when configuring the campaign.
+                 */
+                }
+                {date.getUTCDate()}
+              </li>
+              <li className='DateBox__month-year'>
+                {t('months')[date.getUTCMonth()]} {date.getUTCFullYear()}
+              </li>
+            </ul>
+          }
           <a className='Event__name' href={props.campaignUrl}>{ props.name }</a>
           { this.renderCallToAction() }
         </div>

--- a/src/components/events/UpcomingEvents/index.js
+++ b/src/components/events/UpcomingEvents/index.js
@@ -111,7 +111,7 @@ export default React.createClass({
       var props = {
         key: e.id,
         name: e.name,
-        date: new Date(e.display_start_at),
+        date: e.display_start_at ? new Date(e.display_start_at) : null,
         campaignUrl: e.url,
         donateUrl: e.donate_url,
         getStartedUrl: e.get_started_url,

--- a/src/scss/_version.scss
+++ b/src/scss/_version.scss
@@ -1,1 +1,1 @@
-$ehw-version: "-4.0.8";
+$ehw-version: "-4.0.9";


### PR DESCRIPTION
In the supporter homepage if no date is defined for the campaign 1 jan of 1970 appears.

This will hide the square leaving only the name of the campaign and the action button.