### PR TITLE
Iframe target fix

### DIFF
--- a/src/components/callstoaction/CallToActionBox/index.js
+++ b/src/components/callstoaction/CallToActionBox/index.js
@@ -78,7 +78,7 @@ export default React.createClass({
         <div className='CallToActionBox__title'>{ title }</div>
         <CallToActionButton kind='primary' reverse href={registrationUrl} label={registerLabel} />
         <hr />
-        <p>Already Registered? <a href={signInUrl} className='CallToActionBox__link'>{ signInLabel }</a></p>
+        <p>Already Registered? <a href={signInUrl} target='_top' className='CallToActionBox__link'>{ signInLabel }</a></p>
         <CallToActionButton kind='primary' reverse href={getStartedUrl} label={getStartedLabel} />
       </div>
     )

--- a/src/components/callstoaction/CallToActionButton/index.js
+++ b/src/components/callstoaction/CallToActionButton/index.js
@@ -17,6 +17,7 @@ export default React.createClass({
     thin: React.PropTypes.bool,
     iconLeft: React.PropTypes.bool,
     disabled: React.PropTypes.bool,
+    target: React.PropTypes.oneOf(['_top', '_parent', '_self', '_blank']),
     onClick: React.PropTypes.func
   },
 
@@ -27,6 +28,7 @@ export default React.createClass({
       type: 'button',
       className: '',
       href: null,
+      target: '_top',
       disabled: false,
       thin: false,
       reverse: false,
@@ -74,6 +76,7 @@ export default React.createClass({
         to={href}
         params={props.params}
         href={href}
+        target={props.target}
         onMouseUp={this.handleClick}
         onTouchStart={this.handleClick}>
         <Icon className='CallToActionButton__icon' icon={props.icon} />

--- a/src/components/charities/PromoCharities/index.js
+++ b/src/components/charities/PromoCharities/index.js
@@ -89,7 +89,7 @@ export default React.createClass({
     if (this.props.action === 'custom') {
       this.props.onSelect(charity)
     } else {
-      document.location = this.fetchUrl(charity)
+      window.top.location.href = this.fetchUrl(charity)
     }
   },
 

--- a/src/components/events/CountDown/index.js
+++ b/src/components/events/CountDown/index.js
@@ -39,7 +39,7 @@ export default React.createClass({
 
     if (linkUrl && !isFinished) {
       return (
-        <CallToActionButton href={linkUrl} kind='primary' thin className='CountDown__link'>
+        <CallToActionButton href={linkUrl} target='_top' kind='primary' thin className='CountDown__link'>
           { this.t('link_text') }
         </CallToActionButton>
       )

--- a/src/components/events/Event/index.js
+++ b/src/components/events/Event/index.js
@@ -22,11 +22,13 @@ export default React.createClass({
     centsRaised: React.PropTypes.number,
     currencySymbol: React.PropTypes.string,
     width: React.PropTypes.string.isRequired,
+    target: React.PropTypes.oneOf(['_top', '_parent', '_self', '_blank']),
     i18n: React.PropTypes.object
   },
 
   getDefaultProps: function () {
     return {
+      target: '_top',
       defaultI18n: {
         joinLabel: 'Join Event',
         donateLabel: 'Give Now',
@@ -91,6 +93,7 @@ export default React.createClass({
               kind='secondary'
               reverse
               href={getStartedUrl}
+              target={this.props.target}
               className='Event__block-button'>
               { joinLabel }
             </CallToActionButton>
@@ -104,6 +107,7 @@ export default React.createClass({
               kind='secondary'
               reverse
               href={donateUrl}
+              target={this.props.target}
               className='Event__block-button'>
               { donateLabel }
             </CallToActionButton>
@@ -144,7 +148,7 @@ export default React.createClass({
               </li>
             </ul>
           }
-          <a className='Event__name' href={props.campaignUrl}>{ props.name }</a>
+          <a className='Event__name' target={props.target} href={props.campaignUrl}>{ props.name }</a>
           { this.renderCallToAction() }
         </div>
       </div>

--- a/src/components/footprint/FootprintTile/index.js
+++ b/src/components/footprint/FootprintTile/index.js
@@ -22,6 +22,7 @@ export default React.createClass({
       borderWidth: this.props.offset
     }
     return (<a href={this.props.url}
+      target='_top'
       className='FootprintAvatar'
       title={this.props.name}
       style={avatarStyle}

--- a/src/components/fundraisers/FundraiserImage/index.js
+++ b/src/components/fundraisers/FundraiserImage/index.js
@@ -5,7 +5,7 @@ export default React.createClass({
 
   render: function () {
     return (
-      <a href={this.props.pageUrl} title={this.props.imgTitle} className='FundraiserImage'>
+      <a href={this.props.pageUrl} target='_top' title={this.props.imgTitle} className='FundraiserImage'>
         <img src={this.props.imgSrc} alt={this.props.imgTitle} />
       </a>
     )

--- a/src/components/leaderboards/FitnessLeaderboardItem/index.js
+++ b/src/components/leaderboards/FitnessLeaderboardItem/index.js
@@ -3,6 +3,12 @@ import React from 'react'
 export default React.createClass({
   displayName: 'FitnessLeaderboardItem',
 
+  getDefaultProps: function () {
+    return {
+      target: '_top'
+    }
+  },
+
   render: function () {
     return (
       <tr className='FitnessLeaderboardItem'>

--- a/src/components/leaderboards/LeaderboardItem/index.js
+++ b/src/components/leaderboards/LeaderboardItem/index.js
@@ -12,7 +12,14 @@ export default React.createClass({
     amount: React.PropTypes.string.isRequired,
     width: React.PropTypes.string.isRequired,
     renderImage: React.PropTypes.bool.isRequired,
-    charityName: React.PropTypes.string
+    charityName: React.PropTypes.string,
+    target: React.PropTypes.oneOf(['_top', '_parent', '_self', '_blank'])
+  },
+
+  getDefaultProps: function () {
+    return {
+      target: '_top'
+    }
   },
 
   renderProfileImage: function () {
@@ -39,7 +46,7 @@ export default React.createClass({
     var style = { width: this.props.width }
 
     return (
-      <a href={this.props.url} className='LeaderboardItem' style={style}>
+      <a href={this.props.url} target={this.props.target} className='LeaderboardItem' style={style}>
         <div className='LeaderboardItem__skin'>
           { this.renderProfileImage() }
           <div className='LeaderboardItem__content'>

--- a/src/components/leaderboards/TeamLeaderboardItem/index.js
+++ b/src/components/leaderboards/TeamLeaderboardItem/index.js
@@ -13,7 +13,14 @@ export default React.createClass({
     raisedTitle: React.PropTypes.string.isRequired,
     membersTitle: React.PropTypes.string.isRequired,
     width: React.PropTypes.string.isRequired,
-    charityName: React.PropTypes.string
+    charityName: React.PropTypes.string,
+    target: React.PropTypes.oneOf(['_top', '_parent', '_self', '_blank'])
+  },
+
+  getDefaultProps: function () {
+    return {
+      target: '_top'
+    }
   },
 
   renderCharityName: function () {
@@ -34,7 +41,7 @@ export default React.createClass({
     return (
       <li className='TeamLeaderboard__items-item' style={style}>
         <div className='TeamLeaderboard__items-skin'>
-          <a href={this.props.url} className='TeamLeaderboard__items-image'>
+          <a href={this.props.url} target={this.props.target} className='TeamLeaderboard__items-image'>
             <img src={this.props.imgSrc} />
           </a>
           <div className='TeamLeaderboard__items-content'>

--- a/src/components/search/SearchResult/index.js
+++ b/src/components/search/SearchResult/index.js
@@ -19,7 +19,7 @@ export default React.createClass({
     return (
       <a href={props.result.url || '#'}
         className='SearchResult'
-        target='_parent'
+        target='_top'
         onClick={clickHandler}>
         { props.children }
       </a>

--- a/src/components/supporters/SupporterCard/index.js
+++ b/src/components/supporters/SupporterCard/index.js
@@ -35,7 +35,7 @@ export default React.createClass({
             userName={props.name}
             userUrl={props.url} />
 
-          <a href={props.url} className='SupporterCard__userDetails'>
+          <a href={props.url} target='_top' className='SupporterCard__userDetails'>
             <div className='SupporterCard__name'>{ props.name }</div>
             { props.charityName && <div className='SupporterCard__charity'>For <strong>{ props.charityName }</strong></div> }
             { props.eventName && <div className='SupporterCard__event'>Through <strong>{ props.eventName }</strong></div> }

--- a/src/components/teams/Team/index.js
+++ b/src/components/teams/Team/index.js
@@ -5,7 +5,7 @@ export default React.createClass({
 
   render: function () {
     return (
-      <a href={this.props.pageUrl} title={this.props.title} className='Team'>
+      <a href={this.props.pageUrl} target='_top' title={this.props.title} className='Team'>
         <div className='Team__skin'>
           <img src={this.props.imgSrc} alt={this.props.title} />
           <p>{ this.props.title }</p>


### PR DESCRIPTION
If any of the widgets with links off to an external page are included in an iframe, by default they would open in the same iframe window, which is rarely desired. This increases support (there was already some with a few widgets) for including widgets in iframes, and it is now the default behaviour for all external links to open in the top window.